### PR TITLE
Add Vakt to Authorization - Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [PyCasbin](https://github.com/casbin/pycasbin) - Authorization library that supports access control models like ACL, RBAC, ABAC in Python.
 - [Simple RBAC](https://github.com/tonyseek/simple-rbac) - Simple role-based access control utility for Python.
 - [Flask-RBAC](https://github.com/shonenada/flask-rbac) - Adds RBAC support to [Flask](https://github.com/pallets/flask).
+- [Vakt](https://github.com/kolotaev/vakt) - Attribute-based access control (ABAC) SDK for Python.
 
 ## Articles
 


### PR DESCRIPTION
Vakt is an ABAC SDK written in Python which helps you to implement policy-based authorization solutions in your Python projects: authZ services, in-app authorization, etc.
Project is about 2 years old, is supported and maintained and has got some traction. As far as I know, it's the only known pure-Python solution.