### PR TITLE
feat: Add Authentik

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - [Keycloak](https://www.keycloak.org/) - Open Source Identity and Access Management.
 - [Authelia](https://github.com/authelia/authelia) - The Single Sign-On Multi-Factor portal for web apps.
 - [ZITADEL](https://github.com/caos/zitadel) - Cloud-native Identity & Access Management platform for secure authentication, authorization and identity management.
-- [Authentik](https://goauthentik.io) - authentik is an open-source Identity Provider focused on flexibility and versatility. You can use authentik in an existing environment to add support for new protocols, implement sign-up/recovery/etc.
+- [Authentik](https://goauthentik.io) - authentik is an open-source Identity Provider that emphasizes flexibility and versatility. It can be seamlessly integrated into existing environments to support new protocols.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [Keycloak](https://www.keycloak.org/) - Open Source Identity and Access Management.
 - [Authelia](https://github.com/authelia/authelia) - The Single Sign-On Multi-Factor portal for web apps.
 - [ZITADEL](https://github.com/caos/zitadel) - Cloud-native Identity & Access Management platform for secure authentication, authorization and identity management.
+- [Authentik](https://goauthentik.io) - authentik is an open-source Identity Provider focused on flexibility and versatility. You can use authentik in an existing environment to add support for new protocols, implement sign-up/recovery/etc.
 
 ## Authentication
 


### PR DESCRIPTION
Add [Authentik](https://goauthentik.io) to the list of SSO & IAM software.

Authentik is similar to the tools already listed, and contains a lot of similar functionality.  It [compares itself to, among other things, Keycloak and Authelia](https://goauthentik.io/#comparison), both of which feature in the list already.