### PR TITLE
feat: Add Scalekit to the SSO providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 - [ZITADEL](https://github.com/caos/zitadel) - Cloud-native Identity & Access Management platform for secure authentication, authorization and identity management.
 - [Authentik](https://goauthentik.io) - authentik is an open-source Identity Provider that emphasizes flexibility and versatility. It can be seamlessly integrated into existing environments to support new protocols.
 - [Stack Auth](https://stack-auth.com) - Open-source, developer-friendly authentication, authorization, and IAM solution.
+- [Scalekit](https://scalekit.com) – Add enterprise SSO (SAML, OIDC) and SCIM provisioning on top of existing auth systems like Auth0, Firebase, or Cognito without rewrites.
+
 
 ## Authentication
 


### PR DESCRIPTION
Scalekit helps B2B SaaS teams add enterprise SSO (SAML, OIDC) and SCIM provisioning on top of existing auth systems like Firebase, Auth0, or Cognito — without requiring any rewrites.