### PR TITLE
feat: add client-certificate-auth to Authentication > Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [Passport](https://github.com/jaredhanson/passport) - Simple, unobtrusive authentication for Node.js. A comprehensive set of strategies support authentication using a username and password, Facebook, Twitter, and more.
 - [bell](https://github.com/hapijs/bell) - Third-party authentication plugin for hapi. Ships with built-in support for various well-known sites and simple configuration object will support other OAuth 1.0a and OAuth 2.0 sites.
 - [Stack Auth](https://stack-auth.com) - Open-source authN & authZ for modern web apps, comes with pre-built components for Next.js.
+- [client-certificate-auth](https://github.com/tgies/client-certificate-auth) - Mutual TLS (mTLS) client certificate authentication middleware for Node.js with reverse proxy support, composable verification callbacks, and X.509 certificate parsing.
 
 ### <a name="authN-python"></a>Python
 


### PR DESCRIPTION
Adds [client-certificate-auth](https://github.com/tgies/client-certificate-auth) to the Authentication > Node.js section.

The Node.js section currently covers token-based and OAuth/social authentication. Client certificate authentication (mutual TLS) is a fundamentally different mechanism -- used in zero-trust architectures, service-to-service auth, and high-security environments -- that isn't currently represented in the list.

This package provides:
- Middleware for Express, Connect, and other Node.js HTTP frameworks
- Certificate extraction from TLS connections and reverse proxy headers (AWS ALB, Envoy, Cloudflare, Traefik)
- Composable verification callbacks (`allOf`, `anyOf`)
- X.509 certificate parsing

It has 100% test coverage including mutation testing, E2E tests against real reverse proxy containers, and full TypeScript type definitions.