### PR TITLE
feat: add casbin-fastapi-decorator to Authorization/Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@
 ### <a name="authZ-python"></a>Python
 
 - [PyCasbin](https://github.com/casbin/pycasbin) - Authorization library that supports access control models like ACL, RBAC, ABAC in Python.
-- [casbin-fastapi-decorator](https://github.com/Neko1313/casbin-fastapi-decorator) - Decorator-based authorization for FastAPI using PyCasbin — per-route permissions with no middleware, supports JWT, async SQLAlchemy, and Casdoor.
+- [casbin-fastapi-decorator](https://github.com/Neko1313/casbin-fastapi-decorator) - Decorator-based authorization for FastAPI using PyCasbin, providing per-route permissions with no middleware and support for JWT, async SQLAlchemy, and Casdoor.
 - [Flask-RBAC](https://github.com/shonenada/flask-rbac) - Adds RBAC support to [Flask](https://github.com/pallets/flask).
 - [Vakt](https://github.com/kolotaev/vakt) - Attribute-based access control (ABAC) SDK for Python.
 - [Oso](https://github.com/osohq/oso) - Batteries-included framework for building authorization in your Python application.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 ### <a name="authZ-python"></a>Python
 
 - [PyCasbin](https://github.com/casbin/pycasbin) - Authorization library that supports access control models like ACL, RBAC, ABAC in Python.
+- [casbin-fastapi-decorator](https://github.com/Neko1313/casbin-fastapi-decorator) - Decorator-based authorization for FastAPI using PyCasbin — per-route permissions with no middleware, supports JWT, async SQLAlchemy, and Casdoor.
 - [Flask-RBAC](https://github.com/shonenada/flask-rbac) - Adds RBAC support to [Flask](https://github.com/pallets/flask).
 - [Vakt](https://github.com/kolotaev/vakt) - Attribute-based access control (ABAC) SDK for Python.
 - [Oso](https://github.com/osohq/oso) - Batteries-included framework for building authorization in your Python application.


### PR DESCRIPTION
## What is it?

A decorator-based authorization library for FastAPI built on top of [PyCasbin](https://github.com/casbin/pycasbin). It lets you protect individual routes with a simple decorator instead of setting up global middleware.

```python
guard = PermissionGuard(
    user_provider=get_current_user,
    enforcer_provider=get_enforcer,
    error_factory=lambda user, *rv: HTTPException(403, "Forbidden"),
)

@app.get("/articles")
@guard.require_permission("articles", "read")
async def list_articles():
    return []
```

## Why it belongs here

- Built on **PyCasbin** — a natural extension to the existing entry in this list
- Already listed in the [official Casbin ecosystem](https://casbin.org/ecosystem/) under the FastAPI section
- Unique approach: the only FastAPI+Casbin integration using **decorators** rather than middleware, which means per-route control without global side-effects
- Optional extras: `[jwt]`, `[db]` (async SQLAlchemy), `[casdoor]` (Casdoor OAuth2)
- Available on [PyPI](https://pypi.org/project/casbin-fastapi-decorator/), MIT license, Python 3.10+

## Checklist

- [x] Added to the correct section (Authorization → Python)
- [x] Consistent style with other entries
- [x] Open source (MIT)
- [x] Published on PyPI
- [x] Has documentation and examples