### PR TITLE
fix: add AI Agent Auth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 		- [PHP](#php)
 		- [Python](#python-1)
 		- [Ruby](#ruby-1)
+	- [AI Agent Auth](#ai-agent-auth)
 	- [Articles](#articles)
 	- [Contribute](#contribute)
 	- [License](#license)
@@ -173,6 +174,13 @@
 - [Pundit](https://github.com/varvet/pundit) - Minimal authorization through OO design and pure Ruby classes.
 - [Casbin](https://github.com/CasbinRuby/casbin-ruby) - Authorization library that supports access control models like ACL, RBAC, ABAC in Ruby.
 - [CanCanCan](https://github.com/CanCanCommunity/cancancan) - Authorization for Ruby on Rails.
+
+## AI Agent Auth
+
+- [Arcade](https://github.com/ArcadeAI/arcade-ai) - Tool-calling platform with user approvals and authenticated actions for AI agents.
+- [authsome](https://github.com/agentrhq/authsome) - Local-first credential broker for AI agents with an encrypted local vault and HTTPS proxy injection; no hosted service required.
+- [Composio](https://github.com/ComposioHQ/composio) - Hosted integration platform with managed OAuth and tool calling for 1000+ apps.
+- [Nango](https://github.com/NangoHQ/nango) - Open-source OAuth and API key handling for 700+ APIs with token refresh and a unified API for agent workloads.
 
 ## Articles
 


### PR DESCRIPTION
fix: https://github.com/casdoor/awesome-auth/issues/62

opening this per #62, where @hsluoyz approved a new top-level section.

adds `## AI Agent Auth` between Authorization and Articles, populated with 4 entries from the issue discussion (alphabetical within the section). also updated the Contents toc.

entries: Arcade, authsome, Composio, Nango.

trimmed from the original 6-candidate list to keep the section debut focused on tools with active OSS components or large public adoption. happy to expand to include the others (Anon, Pipedream Connect) in a follow-up if you'd prefer, or drop any individual entry if you'd rather curate the initial set differently. the section structure is the main contribution; the entries can be edited freely.

disclosure: i maintain authsome (already noted in #62).