### PR TITLE
feat: use backend config for frontend auth

### DIFF
--- a/casdoor/init.go
+++ b/casdoor/init.go
@@ -3,18 +3,25 @@ package casdoor
 import (
 	_ "embed"
 
-	"github.com/beego/beego"
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+	"github.com/casosorg/casos/conf"
 )
 
 //go:embed token_jwt_key.pem
 var JwtPublicKey string
 
 func InitCasdoorConfig() {
-	casdoorEndpoint := beego.AppConfig.String("casdoorEndpoint")
-	clientId := beego.AppConfig.String("clientId")
-	clientSecret := beego.AppConfig.String("clientSecret")
-	casdoorOrganization := beego.AppConfig.String("casdoorOrganization")
-	casdoorApplication := beego.AppConfig.String("casdoorApplication")
-	casdoorsdk.InitConfig(casdoorEndpoint, clientId, clientSecret, JwtPublicKey, casdoorOrganization, casdoorApplication)
+	casdoorEndpoint := conf.GetConfigString("casdoorEndpoint")
+	clientId := conf.GetConfigString("clientId")
+	clientSecret := conf.GetConfigString("clientSecret")
+	casdoorOrganization := conf.GetConfigString("casdoorOrganization")
+	casdoorApplication := conf.GetConfigString("casdoorApplication")
+	casdoorsdk.InitConfig(
+		casdoorEndpoint,
+		clientId,
+		clientSecret,
+		JwtPublicKey,
+		casdoorOrganization,
+		casdoorApplication,
+	)
 }

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -1,0 +1,27 @@
+package controllers
+
+import "github.com/casosorg/casos/conf"
+
+type applicationConfig struct {
+	AuthConfig authConfig `json:"authConfig"`
+}
+
+type authConfig struct {
+	ServerURL        string `json:"serverUrl"`
+	ClientID         string `json:"clientId"`
+	AppName          string `json:"appName"`
+	OrganizationName string `json:"organizationName"`
+	RedirectPath     string `json:"redirectPath"`
+}
+
+func (c *ApiController) GetApplicationConfig() {
+	c.ResponseOk(applicationConfig{
+		AuthConfig: authConfig{
+			ServerURL:        conf.GetConfigString("casdoorEndpoint"),
+			ClientID:         conf.GetConfigString("clientId"),
+			AppName:          conf.GetConfigString("casdoorApplication"),
+			OrganizationName: conf.GetConfigString("casdoorOrganization"),
+			RedirectPath:     "/callback",
+		},
+	})
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -9,6 +9,7 @@ func InitAPI() {
 	beego.Router("/api/signin", &controllers.ApiController{}, "POST:Signin")
 	beego.Router("/api/signout", &controllers.ApiController{}, "POST:Signout")
 	beego.Router("/api/get-account", &controllers.ApiController{}, "GET:GetAccount")
+	beego.Router("/api/get-application-config", &controllers.ApiController{}, "GET:GetApplicationConfig")
 
 	beego.Router("/api/get-pods", &controllers.ApiController{}, "GET:GetPods")
 	beego.Router("/api/get-pod", &controllers.ApiController{}, "GET:GetPod")

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -4,6 +4,7 @@ import {StyleProvider, legacyLogicalPropertiesTransformer} from "@ant-design/css
 import {ConfigProvider, FloatButton, Layout} from "antd";
 import * as Setting from "./Setting";
 import * as AccountBackend from "./backend/AccountBackend";
+import * as ConfigBackend from "./backend/ConfigBackend";
 import * as SiteBackend from "./backend/SiteBackend";
 import * as Conf from "./Conf";
 import {getShadcnThemeComponents, getShadcnThemeToken} from "./shadcnTheme";
@@ -14,8 +15,6 @@ import SigninPage from "./SigninPage";
 class App extends Component {
   constructor(props) {
     super(props);
-    Setting.initServerUrl();
-    Setting.initCasdoorSdk(Conf.AuthConfig);
 
     let storageThemeAlgorithm = ["default"];
     try {
@@ -32,12 +31,33 @@ class App extends Component {
       themeAlgorithm: storageThemeAlgorithm,
       site: undefined,
       logo: null,
+      configLoaded: false,
     };
   }
 
-  UNSAFE_componentWillMount() {
-    this.getAccount();
-    this.loadSite();
+  componentDidMount() {
+    this.initConfig();
+  }
+
+  initConfig() {
+    Setting.initServerUrl();
+    ConfigBackend.getApplicationConfig()
+      .then((res) => {
+        if (res.status === "ok") {
+          Conf.setConfig(res.data);
+        } else {
+          Setting.showMessage("error", `Failed to load config: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        Setting.showMessage("error", `Failed to load config: ${error}`);
+      })
+      .then(() => {
+        Setting.initCasdoorSdk(Conf.AuthConfig);
+        this.setState({configLoaded: true});
+        this.getAccount();
+        this.loadSite();
+      });
   }
 
   componentDidUpdate() {
@@ -74,8 +94,13 @@ class App extends Component {
 
   getAccount() {
     AccountBackend.getAccount().then((res) => {
-      const account = res.data;
-      this.setState({account: account});
+      if (res.status === "ok") {
+        this.setState({account: res.data});
+      } else {
+        this.setState({account: null});
+      }
+    }).catch(() => {
+      this.setState({account: null});
     });
   }
 
@@ -106,7 +131,10 @@ class App extends Component {
   };
 
   renderHomeIfSignedIn(component) {
-    if (this.state.account !== null && this.state.account !== undefined) {
+    if (this.state.account === undefined) {
+      return null;
+    }
+    if (this.state.account !== null) {
       return <Redirect to="/" />;
     }
     return component;
@@ -123,6 +151,10 @@ class App extends Component {
   }
 
   renderContent() {
+    if (!this.state.configLoaded) {
+      return null;
+    }
+
     return (
       <Layout id="parent-area">
         <Switch>

--- a/web/src/Conf.js
+++ b/web/src/Conf.js
@@ -1,11 +1,25 @@
 export const AuthConfig = {
-  serverUrl: "https://door.casdoor.com",
-  clientId: "af6b5aa958822fb9dc33",
-  appName: "app-casibase",
-  organizationName: "casbin",
+  serverUrl: "",
+  clientId: "",
+  appName: "",
+  organizationName: "",
   redirectPath: "/callback",
 };
 
 export const ThemeDefault = {
   colorPrimary: "#404040",
 };
+
+export function setConfig(config) {
+  if (config === null || config === undefined) {
+    return;
+  }
+
+  if (config.authConfig) {
+    Object.assign(AuthConfig, config.authConfig);
+  }
+
+  if (config.themeDefault) {
+    Object.assign(ThemeDefault, config.themeDefault);
+  }
+}

--- a/web/src/backend/ConfigBackend.js
+++ b/web/src/backend/ConfigBackend.js
@@ -1,0 +1,8 @@
+import * as Setting from "../Setting";
+
+export function getApplicationConfig() {
+  return fetch(`${Setting.ServerUrl}/api/get-application-config`, {
+    method: "GET",
+    credentials: "include",
+  }).then(res => Setting.handleFetchResponse(res));
+}


### PR DESCRIPTION
## Summary
- Add a backend `/api/get-application-config` endpoint that exposes the public Casdoor frontend config from `conf/app.conf` without returning `clientSecret`.
- Load the auth config at frontend startup before initializing `casdoor-js-sdk`, so `web/src/Conf.js` no longer contains environment-specific Casdoor values.
- Reuse backend config helpers for Casdoor server initialization so environment variable overrides stay consistent.

Fixes #75

## Test plan
- [x] `git diff --check`
- [x] `cd web && corepack yarn@1.22.22 install --frozen-lockfile`
- [x] `cd web && ./node_modules/.bin/eslint src/App.js src/Conf.js src/backend/ConfigBackend.js`
- [x] `cd web && corepack yarn@1.22.22 build`
- [x] `go test ./...`
- [x] `go build -o casos.exe .`