### PR TITLE
feat: stabilize pod terminal websocket

### DIFF
--- a/controllers/terminal.go
+++ b/controllers/terminal.go
@@ -56,21 +56,29 @@ func pumpTerminalInput(
 	resizeCh chan<- termResizeMsg,
 	cancel context.CancelFunc,
 ) {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			// Closing the WebSocket unblocks ReadMessage when the exec context ends.
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
+	defer close(done)
 	defer cancel()
 	defer close(resizeCh)
 	defer stdin.Close()
 
 	for {
-		select {
-		case <-ctx.Done():
-			_ = stdin.CloseWithError(ctx.Err())
-			return
-		default:
-		}
-
 		_, msg, err := conn.ReadMessage()
 		if err != nil {
-			_ = stdin.CloseWithError(err)
+			if ctx.Err() != nil {
+				_ = stdin.CloseWithError(ctx.Err())
+			} else {
+				_ = stdin.CloseWithError(err)
+			}
 			return
 		}
 		if len(msg) == 0 {
@@ -141,8 +149,8 @@ func (c *ApiController) PodTerminal() {
 	}
 	defer conn.Close()
 
-	clientset, err := kubernetes.NewForConfig(cfg)
 	writeMu := &sync.Mutex{}
+	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		writeTerminalMessage(conn, writeMu, "k8s client error: "+err.Error())
 		return
@@ -158,7 +166,7 @@ func (c *ApiController) PodTerminal() {
 			Command:   []string{"sh", "-c", "if command -v bash >/dev/null 2>&1; then exec bash; else exec sh; fi"},
 			Stdin:     true,
 			Stdout:    true,
-			Stderr:    false,
+			Stderr:    false, // TTY mode combines stderr into stdout, so use one output stream.
 			TTY:       true,
 		}, scheme.ParameterCodec)
 

--- a/controllers/terminal.go
+++ b/controllers/terminal.go
@@ -1,14 +1,23 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	terminalInputFrame  byte = 0
+	terminalResizeFrame byte = 1
 )
 
 var wsUpgrader = websocket.Upgrader{
@@ -21,61 +30,72 @@ type termResizeMsg struct {
 }
 
 // wsPipeWriter forwards bytes to the WebSocket client.
-type wsPipeWriter struct{ conn *websocket.Conn }
+type wsPipeWriter struct {
+	conn *websocket.Conn
+	mu   *sync.Mutex
+}
 
 func (w *wsPipeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if err := w.conn.WriteMessage(websocket.BinaryMessage, p); err != nil {
 		return 0, err
 	}
 	return len(p), nil
 }
 
-// wsPipeReader reads stdin from the WebSocket client.
-// Binary frame protocol (first byte = message type):
+// Binary frame protocol from browser to backend:
 //
 //	0 — stdin data (rest of frame is the raw bytes)
 //	1 — terminal resize (rest of frame is JSON {"cols":N,"rows":N})
-type wsPipeReader struct {
-	conn     *websocket.Conn
-	buf      []byte
-	resizeCh chan termResizeMsg
-}
+func pumpTerminalInput(
+	ctx context.Context,
+	conn *websocket.Conn,
+	stdin *io.PipeWriter,
+	resizeCh chan<- termResizeMsg,
+	cancel context.CancelFunc,
+) {
+	defer cancel()
+	defer close(resizeCh)
+	defer stdin.Close()
 
-func (r *wsPipeReader) Read(p []byte) (int, error) {
 	for {
-		if len(r.buf) > 0 {
-			n := copy(p, r.buf)
-			r.buf = r.buf[n:]
-			return n, nil
+		select {
+		case <-ctx.Done():
+			_ = stdin.CloseWithError(ctx.Err())
+			return
+		default:
 		}
-		_, msg, err := r.conn.ReadMessage()
+
+		_, msg, err := conn.ReadMessage()
 		if err != nil {
-			return 0, err
+			_ = stdin.CloseWithError(err)
+			return
 		}
 		if len(msg) == 0 {
 			continue
 		}
+
 		switch msg[0] {
-		case 0: // stdin
-			data := msg[1:]
-			n := copy(p, data)
-			if n < len(data) {
-				r.buf = data[n:]
+		case terminalInputFrame:
+			if _, err := stdin.Write(msg[1:]); err != nil {
+				return
 			}
-			return n, nil
-		case 1: // resize
+		case terminalResizeFrame:
 			var sz termResizeMsg
-			if json.Unmarshal(msg[1:], &sz) == nil {
-				select {
-				case r.resizeCh <- sz:
-				default:
-				}
+			if err := json.Unmarshal(msg[1:], &sz); err != nil {
+				continue
+			}
+			select {
+			case resizeCh <- sz:
+			default:
 			}
 		}
 	}
 }
 
-type termSizeQueue struct{ ch chan termResizeMsg }
+type termSizeQueue struct{ ch <-chan termResizeMsg }
 
 func (q *termSizeQueue) Next() *remotecommand.TerminalSize {
 	sz, ok := <-q.ch
@@ -83,6 +103,13 @@ func (q *termSizeQueue) Next() *remotecommand.TerminalSize {
 		return nil
 	}
 	return &remotecommand.TerminalSize{Width: sz.Cols, Height: sz.Rows}
+}
+
+func writeTerminalMessage(conn *websocket.Conn, mu *sync.Mutex, msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	_ = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("\r\n%s\r\n", msg)))
 }
 
 // PodTerminal opens an interactive WebSocket terminal into a pod container.
@@ -103,6 +130,10 @@ func (c *ApiController) PodTerminal() {
 	if namespace == "" {
 		namespace = "default"
 	}
+	if name == "" {
+		c.ResponseError("name is required")
+		return
+	}
 
 	conn, err := wsUpgrader.Upgrade(c.Ctx.ResponseWriter, c.Ctx.Request, nil)
 	if err != nil {
@@ -111,8 +142,9 @@ func (c *ApiController) PodTerminal() {
 	defer conn.Close()
 
 	clientset, err := kubernetes.NewForConfig(cfg)
+	writeMu := &sync.Mutex{}
 	if err != nil {
-		_ = conn.WriteMessage(websocket.BinaryMessage, []byte("k8s client error: "+err.Error()))
+		writeTerminalMessage(conn, writeMu, "k8s client error: "+err.Error())
 		return
 	}
 
@@ -123,28 +155,35 @@ func (c *ApiController) PodTerminal() {
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: container,
-			Command:   []string{"sh", "-c", "bash 2>/dev/null || sh"},
+			Command:   []string{"sh", "-c", "if command -v bash >/dev/null 2>&1; then exec bash; else exec sh; fi"},
 			Stdin:     true,
 			Stdout:    true,
-			Stderr:    true,
+			Stderr:    false,
 			TTY:       true,
 		}, scheme.ParameterCodec)
 
-	resizeCh := make(chan termResizeMsg, 4)
-	reader := &wsPipeReader{conn: conn, resizeCh: resizeCh}
-	writer := &wsPipeWriter{conn: conn}
-
 	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
 	if err != nil {
-		_ = conn.WriteMessage(websocket.BinaryMessage, []byte("exec error: "+err.Error()))
+		writeTerminalMessage(conn, writeMu, "exec error: "+err.Error())
 		return
 	}
 
-	_ = exec.StreamWithContext(c.Ctx.Request.Context(), remotecommand.StreamOptions{
-		Stdin:             reader,
+	ctx, cancel := context.WithCancel(c.Ctx.Request.Context())
+	defer cancel()
+
+	stdinReader, stdinWriter := io.Pipe()
+	defer stdinReader.Close()
+
+	resizeCh := make(chan termResizeMsg, 4)
+	go pumpTerminalInput(ctx, conn, stdinWriter, resizeCh, cancel)
+
+	writer := &wsPipeWriter{conn: conn, mu: writeMu}
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:             stdinReader,
 		Stdout:            writer,
-		Stderr:            writer,
 		Tty:               true,
 		TerminalSizeQueue: &termSizeQueue{ch: resizeCh},
-	})
+	}); err != nil && ctx.Err() == nil {
+		writeTerminalMessage(conn, writeMu, "terminal error: "+err.Error())
+	}
 }

--- a/controllers/terminal.go
+++ b/controllers/terminal.go
@@ -66,8 +66,8 @@ func pumpTerminalInput(
 		}
 	}()
 
-	defer close(done)
 	defer cancel()
+	defer close(done)
 	defer close(resizeCh)
 	defer stdin.Close()
 

--- a/web/src/PodTerminalDrawer.js
+++ b/web/src/PodTerminalDrawer.js
@@ -76,17 +76,14 @@ function PodTerminalDrawer({pod, open, onClose}) {
       sendResize(term.cols, term.rows);
     };
 
-    ws.onmessage = async(e) => {
+    ws.onmessage = (e) => {
       if (termRef.current !== term) {return;}
       if (typeof e.data === "string") {
         term.write(e.data);
         return;
       }
 
-      const buffer = e.data instanceof Blob ? await e.data.arrayBuffer() : e.data;
-      if (termRef.current === term) {
-        term.write(new Uint8Array(buffer));
-      }
+      term.write(new Uint8Array(e.data));
     };
 
     ws.onclose = () => {

--- a/web/src/PodTerminalDrawer.js
+++ b/web/src/PodTerminalDrawer.js
@@ -87,11 +87,15 @@ function PodTerminalDrawer({pod, open, onClose}) {
     };
 
     ws.onclose = () => {
-      term.write("\r\n\x1b[31m[connection closed]\x1b[0m\r\n");
+      if (termRef.current === term) {
+        term.write("\r\n\x1b[31m[connection closed]\x1b[0m\r\n");
+      }
     };
 
     ws.onerror = () => {
-      term.write("\r\n\x1b[31m[websocket error]\x1b[0m\r\n");
+      if (termRef.current === term) {
+        term.write("\r\n\x1b[31m[websocket error]\x1b[0m\r\n");
+      }
     };
 
     // stdin: send user keystrokes

--- a/web/src/PodTerminalDrawer.js
+++ b/web/src/PodTerminalDrawer.js
@@ -2,6 +2,7 @@ import React, {useEffect, useRef} from "react";
 import {Drawer, Select, Space} from "antd";
 import {Terminal} from "xterm";
 import {FitAddon} from "xterm-addon-fit";
+import * as Setting from "./Setting";
 import "xterm/css/xterm.css";
 
 /**
@@ -62,9 +63,11 @@ function PodTerminalDrawer({pod, open, onClose}) {
       fitAddon.fit();
     }
 
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const params = new URLSearchParams({namespace: ns, name, container: ctr});
-    const ws = new WebSocket(`${protocol}//${window.location.host}/api/pod-terminal?${params}`);
+    const ws = new WebSocket(Setting.getWebSocketUrl("/api/pod-terminal", {
+      namespace: ns,
+      name,
+      container: ctr,
+    }));
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
 
@@ -73,9 +76,17 @@ function PodTerminalDrawer({pod, open, onClose}) {
       sendResize(term.cols, term.rows);
     };
 
-    ws.onmessage = (e) => {
-      const data = new Uint8Array(e.data);
-      term.write(data);
+    ws.onmessage = async(e) => {
+      if (termRef.current !== term) {return;}
+      if (typeof e.data === "string") {
+        term.write(e.data);
+        return;
+      }
+
+      const buffer = e.data instanceof Blob ? await e.data.arrayBuffer() : e.data;
+      if (termRef.current === term) {
+        term.write(new Uint8Array(buffer));
+      }
     };
 
     ws.onclose = () => {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -18,6 +18,18 @@ export function initCasdoorSdk(config) {
   CasdoorSdk = new Sdk(config);
 }
 
+export function getWebSocketUrl(path, params = {}) {
+  const baseUrl = ServerUrl || window.location.origin;
+  const url = new URL(path, baseUrl);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== null && value !== undefined) {
+      url.searchParams.set(key, value);
+    }
+  });
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
 export function getSigninUrl() {
   return CasdoorSdk.getSigninUrl();
 }


### PR DESCRIPTION
## Summary
- Fix pod terminal WebSocket input handling by decoupling browser reads from Kubernetes exec stdin.
- Serialize WebSocket writes and report terminal errors back to the client.
- Reuse the frontend server URL helper for terminal WebSocket connections.

Fixes #77
