### PR TITLE
feat: add failing e2e ui test demo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,67 @@ jobs:
           name: frontend-build-${{ github.run_id }}
           path: ./web/build
 
+  ui-tests:
+    name: UI tests
+    runs-on: ubuntu-latest
+    needs: [ go-tests ]
+    permissions:
+      contents: read
+      actions: write
+    timeout-minutes: 20
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: casos-${{ github.run_id }}-${{ github.run_attempt }}
+          MYSQL_DATABASE: casos
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -p$MYSQL_ROOT_PASSWORD"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      dataSourceName: root:casos-${{ github.run_id }}-${{ github.run_attempt }}@tcp(127.0.0.1:3306)/
+      dbName: casos
+      socks5Proxy: ""
+      E2E_DATA_DIR: /tmp/casos-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+      E2E_APISERVER_PORT: 16443
+      E2E_WEBHOOK_PORT: 19443
+      E2E_TEST_TOKEN: casos-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: ./go.mod
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+          cache-dependency-path: ./web/yarn.lock
+      - run: yarn install
+        working-directory: ./web
+      - run: yarn playwright install --with-deps chromium
+        working-directory: ./web
+      - name: Run UI tests
+        working-directory: ./web
+        shell: bash
+        run: |
+          set -o pipefail
+          yarn run ui:test 2>&1 | tee ui-test.log
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts-${{ github.run_id }}
+          path: |
+            ./web/playwright-report
+            ./web/test-results
+            ./web/ui-test.log
+          if-no-files-found: ignore
+
   backend:
     name: Back-end
     runs-on: ubuntu-latest
@@ -87,7 +148,7 @@ jobs:
       contents: write
       issues: write
     if: github.repository == 'casosorg/casos' && github.event_name == 'push'
-    needs: [ frontend, backend, linter ]
+    needs: [ frontend, ui-tests, backend, linter ]
     outputs:
       new-release-published: ${{ steps.semantic.outputs.new_release_published }}
       new-release-version: ${{ steps.semantic.outputs.new_release_version }}

--- a/controllers/e2e.go
+++ b/controllers/e2e.go
@@ -1,0 +1,40 @@
+package controllers
+
+import (
+	"github.com/beego/beego/logs"
+	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
+
+	"github.com/casosorg/casos/conf"
+)
+
+const e2eTokenHeader = "X-Casos-E2E-Token"
+
+func (c *ApiController) E2ESignin() {
+	if !conf.GetConfigBool("e2eTestMode") {
+		c.ResponseError("E2E test mode is disabled")
+		return
+	}
+
+	token := conf.GetConfigString("e2eTestToken")
+	if token == "" {
+		c.ResponseError("E2E test token is not configured")
+		return
+	}
+	if c.Ctx.Input.Header(e2eTokenHeader) != token {
+		c.ResponseError("invalid E2E token")
+		return
+	}
+
+	claims := &casdoorsdk.Claims{
+		User: casdoorsdk.User{
+			Owner:       "built-in",
+			Name:        "ci-user",
+			DisplayName: "CI User",
+			IsAdmin:     true,
+		},
+	}
+	c.SetSessionClaims(claims)
+	logs.Info("E2E test sign-in used for user %s", claims.Name)
+
+	c.ResponseOk(claims.User)
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"github.com/beego/beego"
+	"github.com/casosorg/casos/conf"
 	"github.com/casosorg/casos/controllers"
 )
 
@@ -9,6 +10,9 @@ func InitAPI() {
 	beego.Router("/api/signin", &controllers.ApiController{}, "POST:Signin")
 	beego.Router("/api/signout", &controllers.ApiController{}, "POST:Signout")
 	beego.Router("/api/get-account", &controllers.ApiController{}, "GET:GetAccount")
+	if conf.GetConfigBool("e2eTestMode") {
+		beego.Router("/api/e2e/signin", &controllers.ApiController{}, "POST:E2ESignin")
+	}
 
 	beego.Router("/api/get-pods", &controllers.ApiController{}, "GET:GetPods")
 	beego.Router("/api/get-pod", &controllers.ApiController{}, "GET:GetPod")

--- a/server/config.go
+++ b/server/config.go
@@ -3,9 +3,10 @@ package server
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
-	"github.com/beego/beego"
+	"github.com/casosorg/casos/conf"
 )
 
 // Config holds control-plane settings populated from app.conf.
@@ -22,23 +23,23 @@ type Config struct {
 
 // ConfigFromAppConf reads server config from the beego app.conf.
 func ConfigFromAppConf() (Config, error) {
-	dataDir := beego.AppConfig.String("dataDir")
+	dataDir := conf.GetConfigString("dataDir")
 	if dataDir == "" {
 		dataDir = "/var/lib/casos"
 	}
-	bind := beego.AppConfig.String("apiserverBind")
+	bind := conf.GetConfigString("apiserverBind")
 	if bind == "" {
 		bind = outboundIP()
 	}
-	port, _ := beego.AppConfig.Int("apiserverPort")
+	port := configInt("apiserverPort")
 	if port == 0 {
 		port = 6443
 	}
-	dsn := beego.AppConfig.String("dataSourceName")
+	dsn := conf.GetConfigString("dataSourceName")
 	if dsn == "" {
 		return Config{}, fmt.Errorf("dataSourceName not set in app.conf")
 	}
-	dbName := beego.AppConfig.String("dbName")
+	dbName := conf.GetConfigString("dbName")
 	if dbName == "" {
 		dbName = "casos"
 	}
@@ -49,14 +50,14 @@ func ConfigFromAppConf() (Config, error) {
 		advertise = bind
 	}
 
-	webhookPort, _ := beego.AppConfig.Int("webhookPort")
+	webhookPort := configInt("webhookPort")
 	if webhookPort == 0 {
 		webhookPort = 9443
 	}
 
-	socks5Proxy := beego.AppConfig.String("socks5Proxy")
+	socks5Proxy := conf.GetConfigString("socks5Proxy")
 
-	sandboxImage := beego.AppConfig.String("sandboxImage")
+	sandboxImage := conf.GetConfigString("sandboxImage")
 	if sandboxImage == "" {
 		if socks5Proxy != "" {
 			sandboxImage = "registry.aliyuncs.com/google_containers/pause:3.10.1"
@@ -75,6 +76,18 @@ func ConfigFromAppConf() (Config, error) {
 		SandboxImage:     sandboxImage,
 		Socks5Proxy:      socks5Proxy,
 	}, nil
+}
+
+func configInt(key string) int {
+	value := conf.GetConfigString(key)
+	if value == "" {
+		return 0
+	}
+	res, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return res
 }
 
 // injectDBName inserts dbName into a MySQL DSN of the form

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,8 @@
   "scripts": {
     "start": "cross-env PORT=8001 craco start",
     "build": "craco build",
+    "ui:test": "playwright test",
+    "ui:test:headed": "playwright test --headed",
     "fix": "eslint --fix src/ --ext .js",
     "lint:js": "eslint --fix src/ --ext .js",
     "lint:css": "stylelint src/**/*.{css,less} --fix",
@@ -35,6 +37,7 @@
     "@babel/eslint-parser": "^7.18.9",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-react": "^7.18.6",
+    "@playwright/test": "^1.61.1",
     "eslint": "8.22.0",
     "eslint-plugin-react": "^7.31.1",
     "eslint-plugin-unused-imports": "^2.0.0",

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -1,0 +1,68 @@
+const {randomUUID} = require("crypto");
+const os = require("os");
+const path = require("path");
+const {defineConfig, devices} = require("@playwright/test");
+
+const backendPort = Number(process.env.E2E_BACKEND_PORT || 9000);
+const frontendPort = Number(process.env.E2E_FRONTEND_PORT || 8001);
+const baseURL = `http://127.0.0.1:${frontendPort}`;
+const backendURL = `http://127.0.0.1:${backendPort}`;
+const e2eToken = process.env.E2E_TEST_TOKEN || randomUUID();
+const e2eDataDir = process.env.E2E_DATA_DIR || path.join(os.tmpdir(), `casos-e2e-${process.pid}`);
+const backendDir = path.resolve(__dirname, "..");
+
+process.env.E2E_TEST_TOKEN = e2eToken;
+
+module.exports = defineConfig({
+  testDir: "./tests/ui",
+  outputDir: "test-results",
+  timeout: 30 * 1000,
+  expect: {
+    timeout: 10 * 1000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", {open: "never"}]] : "list",
+  use: {
+    baseURL,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {...devices["Desktop Chrome"]},
+    },
+  ],
+  webServer: [
+    {
+      command: `cd "${backendDir}" && go run main.go -createDatabase=true`,
+      url: `${backendURL}/api/get-built-in-site`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180 * 1000,
+      env: {
+        ...process.env,
+        httpport: String(backendPort),
+        dataDir: e2eDataDir,
+        apiserverPort: process.env.E2E_APISERVER_PORT || "16443",
+        webhookPort: process.env.E2E_WEBHOOK_PORT || "19443",
+        socks5Proxy: process.env.socks5Proxy || "",
+        e2eTestMode: "true",
+        e2eTestToken: e2eToken,
+      },
+    },
+    {
+      command: "yarn start",
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+      env: {
+        ...process.env,
+        BROWSER: "none",
+        CI: "false",
+        PORT: String(frontendPort),
+      },
+    },
+  ],
+});

--- a/web/tests/ui/site-e2e.spec.js
+++ b/web/tests/ui/site-e2e.spec.js
@@ -1,0 +1,37 @@
+const {expect, test} = require("@playwright/test");
+
+const e2eToken = process.env.E2E_TEST_TOKEN;
+
+test("renders the built-in site editor through the real backend", async ({page}) => {
+  expect(e2eToken).toBeTruthy();
+
+  await page.addInitScript(() => {
+    localStorage.setItem("language", "en");
+  });
+
+  const signin = await page.context().request.post("/api/e2e/signin", {
+    headers: {
+      "X-Casos-E2E-Token": e2eToken,
+    },
+  });
+  expect(signin.ok()).toBeTruthy();
+  await expect(signin).toBeOK();
+  await expect(signin.json()).resolves.toMatchObject({
+    status: "ok",
+    data: {
+      name: "ci-user",
+      displayName: "CI User",
+    },
+  });
+
+  await page.goto("/sites/site-built-in");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page).toHaveURL(/\/sites\/site-built-in$/);
+  await expect(page.locator("#parent-area")).toBeVisible();
+  await expect(page.getByText("CI User")).toBeVisible();
+  await expect(page.getByText("Edit Site")).toBeVisible();
+  await expect(page.getByDisplayValue("site-built-in")).toBeVisible();
+  await expect(page.getByText("CI failure demo marker")).toBeVisible();
+  await expect(page.getByRole("button", {name: "Save"}).first()).toBeVisible();
+});

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1703,6 +1703,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@playwright/test@^1.61.1":
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
+  dependencies:
+    playwright "1.61.1"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.17"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz#8c2f34ca8651df74895422046e11ce5a120e7930"
@@ -5707,6 +5714,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -8323,6 +8335,20 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
+
+playwright@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
+  dependencies:
+    playwright-core "1.61.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Summary:
- Add the same backend-backed Playwright UI E2E CI setup as the success control.
- Intentionally add a failing UI assertion so GitHub Actions should produce failed-test artifacts.
- Use this draft PR only to verify the uploaded HTML report, test results, trace, screenshots, video, and ui-test.log.

Validation expectation:
- UI tests are expected to fail.
- Playwright artifacts should be uploaded by the UI tests job.

Control group: expected failure PR.

No corresponding issue.