### PR TITLE
feat: add control plane egress policy

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/beego/beego/logs"
 	"github.com/casosorg/casos/object"
+	proxypkg "github.com/casosorg/casos/proxy"
 	"github.com/casosorg/casos/store"
 )
 
@@ -66,7 +67,8 @@ func (c *ApiController) SearchArtifactHub() {
 		url += "&ts_query_web=" + q
 	}
 
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := *proxypkg.GetHttpClient(url)
+	client.Timeout = 15 * time.Second
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("Accept", "application/json")
 

--- a/proxy/egress_policy.go
+++ b/proxy/egress_policy.go
@@ -1,0 +1,121 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+// EgressPolicy selects the control-plane proxy for each outbound request.
+type EgressPolicy struct {
+	proxyForURL func(*url.URL) (*url.URL, error)
+}
+
+// NewEgressPolicy builds a request-level proxy policy. A blank proxy address
+// preserves the standard library's environment proxy behavior.
+func NewEgressPolicy(proxyAddress, noProxy string) (*EgressPolicy, error) {
+	proxyAddress = strings.TrimSpace(proxyAddress)
+	if proxyAddress == "" {
+		return &EgressPolicy{
+			proxyForURL: func(requestURL *url.URL) (*url.URL, error) {
+				return http.ProxyFromEnvironment(&http.Request{URL: requestURL})
+			},
+		}, nil
+	}
+
+	normalized, err := normalizeSocks5ProxyAddress(proxyAddress)
+	if err != nil {
+		return nil, err
+	}
+	proxyConfig := &httpproxy.Config{
+		HTTPProxy:  normalized,
+		HTTPSProxy: normalized,
+		NoProxy:    noProxy,
+	}
+	return &EgressPolicy{proxyForURL: proxyConfig.ProxyFunc()}, nil
+}
+
+// Proxy implements the proxy callback used by http.Transport.
+func (p *EgressPolicy) Proxy(req *http.Request) (*url.URL, error) {
+	if p == nil || p.proxyForURL == nil {
+		return nil, nil
+	}
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("cannot select proxy for a request without a URL")
+	}
+	return p.proxyForURL(req.URL)
+}
+
+// HTTPClient returns a client whose transport retains the standard defaults
+// while applying this policy independently to every request and redirect.
+func (p *EgressPolicy) HTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = p.Proxy
+	return &http.Client{Transport: transport}
+}
+
+func normalizeSocks5ProxyAddress(raw string) (string, error) {
+	candidate := strings.TrimSpace(raw)
+	if !strings.Contains(candidate, "://") {
+		candidate = "socks5h://" + candidate
+	}
+
+	parsed, err := url.Parse(candidate)
+	if err != nil {
+		return "", invalidProxyAddressError(raw)
+	}
+	if parsed.Scheme != "socks5" && parsed.Scheme != "socks5h" {
+		return "", invalidProxyAddressError(raw)
+	}
+	if parsed.Hostname() == "" || parsed.Port() == "" {
+		return "", invalidProxyAddressError(raw)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port < 1 || port > 65535 {
+		return "", invalidProxyAddressError(raw)
+	}
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", invalidProxyAddressError(raw)
+	}
+
+	normalized := &url.URL{
+		Scheme: "socks5h",
+		User:   parsed.User,
+		Host:   net.JoinHostPort(parsed.Hostname(), parsed.Port()),
+	}
+	return normalized.String(), nil
+}
+
+func invalidProxyAddressError(raw string) error {
+	return fmt.Errorf("invalid SOCKS5 proxy address %q", RedactProxyAddress(raw))
+}
+
+// RedactProxyAddress removes a proxy password while retaining the endpoint for
+// diagnostics. Malformed values are fully redacted because they cannot be
+// parsed without risking credential disclosure.
+func RedactProxyAddress(raw string) string {
+	candidate := strings.TrimSpace(raw)
+	addedScheme := !strings.Contains(candidate, "://")
+	if addedScheme {
+		candidate = "redact://" + candidate
+	}
+	parsed, err := url.Parse(candidate)
+	if err != nil {
+		return "REDACTED"
+	}
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.UserPassword(parsed.User.Username(), "REDACTED")
+		}
+	}
+	redacted := parsed.String()
+	if addedScheme {
+		redacted = strings.TrimPrefix(redacted, "redact://")
+	}
+	return redacted
+}

--- a/proxy/socks5.go
+++ b/proxy/socks5.go
@@ -1,15 +1,14 @@
 package proxy
 
 import (
-	"crypto/tls"
 	"net"
 	"net/http"
-	"strings"
+	"net/url"
 	"time"
 
 	"github.com/beego/beego/logs"
 	"github.com/casosorg/casos/conf"
-	"golang.org/x/net/proxy"
+	"golang.org/x/net/http/httpproxy"
 )
 
 var (
@@ -18,16 +17,27 @@ var (
 )
 
 func InitHttpClient() {
-	// not use proxy
-	DefaultHttpClient = http.DefaultClient
-
-	// use proxy
-	ProxyHttpClient = getProxyHttpClient()
+	policy, err := NewEgressPolicy(GetSocks5ProxyAddress(), httpproxy.FromEnvironment().NoProxy)
+	if err != nil {
+		logs.Error("Control-plane egress blocked by invalid proxy configuration: %v", err)
+		policy = &EgressPolicy{
+			proxyForURL: func(*url.URL) (*url.URL, error) {
+				return nil, err
+			},
+		}
+	}
+	client := policy.HTTPClient()
+	DefaultHttpClient = client
+	ProxyHttpClient = client
 }
 
 func isAddressOpen(address string) bool {
+	dialAddress, err := proxyDialAddress(address)
+	if err != nil {
+		return false
+	}
 	timeout := time.Millisecond * 100
-	conn, err := net.DialTimeout("tcp", address, timeout)
+	conn, err := net.DialTimeout("tcp", dialAddress, timeout)
 	if err != nil {
 		// cannot connect to address, proxy is not active
 		return false
@@ -35,33 +45,23 @@ func isAddressOpen(address string) bool {
 
 	if conn != nil {
 		defer conn.Close()
-		logs.Info("Socks5 proxy enabled: %s", address)
+		logs.Info("Socks5 proxy enabled: %s", RedactProxyAddress(address))
 		return true
 	}
 
 	return false
 }
 
-func getProxyHttpClient() *http.Client {
-	socks5Proxy := conf.GetConfigString("socks5Proxy")
-	if socks5Proxy == "" {
-		return &http.Client{}
-	}
-
-	if !isAddressOpen(socks5Proxy) {
-		return &http.Client{}
-	}
-
-	// https://stackoverflow.com/questions/33585587/creating-a-go-socks5-client
-	dialer, err := proxy.SOCKS5("tcp", socks5Proxy, nil, proxy.Direct)
+func proxyDialAddress(address string) (string, error) {
+	normalized, err := normalizeSocks5ProxyAddress(address)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-
-	tr := &http.Transport{Dial: dialer.Dial, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	return &http.Client{
-		Transport: tr,
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return "", invalidProxyAddressError(address)
 	}
+	return parsed.Host, nil
 }
 
 func GetSocks5ProxyAddress() string {
@@ -76,10 +76,6 @@ func GetActiveSocks5ProxyAddress() string {
 	return socks5Proxy
 }
 
-func GetHttpClient(url string) *http.Client {
-	if strings.Contains(url, "hub.docker.com") {
-		return ProxyHttpClient
-	} else {
-		return DefaultHttpClient
-	}
+func GetHttpClient(_ string) *http.Client {
+	return ProxyHttpClient
 }


### PR DESCRIPTION
## Summary

- add a typed request-level control-plane egress policy
- route ArtifactHub, Helm HTTP/OCI, and Docker Hub API traffic through the same policy
- preserve TLS verification, honor NO_PROXY, redact credentials, and fail closed when an explicitly configured proxy is invalid or unavailable

## Impact

This PR only covers CasOS control-plane downloads and APIs. It does not modify Chart values, Pod image fields, node bootstrap downloads, containerd image pulls, or Pod runtime traffic.

The end-to-end case where YAML omits the image registry is implemented by the registry-routing and containerd-lifecycle PRs.

## Validation

- go test -race ./proxy
- go test ./proxy ./controllers ./store
- go test ./...
- git diff --check

CasOS repository policy excludes Go *_test.go files from the published change, so the TDD tests used locally are not included in this PR.

Open Code Review could not run because node is unavailable in the WSL environment.