### PR TITLE
chore: ignore local build output and runtime data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ go.work.sum
 
 tmp/
 
+# Local build output
+/casos
+
+# Local runtime data (certs, kine storage, etc.)
+/data/
+
 # Editor/IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## What

Add two entries to `.gitignore`:

- `/casos` — the compiled binary produced by `go build -o casos .` (per README)
- `/data/` — the runtime data directory (certs, kine storage, etc.)

## Why

The build output is a ~270MB binary and `data/` contains sensitive runtime artifacts (TLS certs, kube data). Both currently show as untracked files and are easy to commit accidentally. This is the standard ignore pattern for local dev/run artifacts.