### PR TITLE
fix: point kubelet resolvConf at real upstream DNS

### DIFF
--- a/deploy/kubelet.go
+++ b/deploy/kubelet.go
@@ -22,6 +22,7 @@ containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
 clusterDNS:
   - %s
 clusterDomain: cluster.local
+resolvConf: /etc/casos-resolv.conf
 `, nodeDeployClusterDNS)
 }
 


### PR DESCRIPTION
## What

Add `resolvConf: /etc/casos-resolv.conf` to the kubelet configuration generated by the node installer.

## Why

On hosts running systemd-resolved, `/etc/resolv.conf` is a stub pointing at `127.0.0.53`. Pods with `dnsPolicy: Default` — including the managed CoreDNS deployment — inherit this stub inside their network namespace. Since CoreDNS listens on `0.0.0.0:53`, its `forward` plugin sends queries back to itself, triggering the `loop` detector and a fatal exit (CrashLoopBackOff).

The node installer already generates `/etc/casos-resolv.conf` from the real upstream resolver (`/run/systemd/resolve/resolv.conf`) via deploy/installer.go, but nothing referenced it. This wires it up as kubelet's `resolvConf`, so Default-policy pods receive the actual upstream DNS servers.

## Verification

Manually reproduced on a local worker: with this config in place, CoreDNS starts cleanly (`Loop detected` gone) and resolves external names via the real resolver.