### PR TITLE
fix: allow ip_forward sysctl in generated kubelet config

### DIFF
--- a/deploy/kubelet.go
+++ b/deploy/kubelet.go
@@ -22,6 +22,9 @@ containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
 clusterDNS:
   - %s
 clusterDomain: cluster.local
+allowedUnsafeSysctls:
+  - net.ipv4.ip_forward
+  - net.ipv6.conf.all.forwarding
 `, nodeDeployClusterDNS)
 }
 


### PR DESCRIPTION
## What

Add `allowedUnsafeSysctls` (`net.ipv4.ip_forward`, `net.ipv6.conf.all.forwarding`) to the kubelet configuration generated by the node installer.

## Why
<img width="2120" height="245" alt="screen" src="https://github.com/user-attachments/assets/6c348442-1bb4-4778-ac7b-004a7bdef9f3" />



The built-in ServiceLB creates svclb DaemonSet pods that set these sysctls in their pod security context (server/servicelb.go). Without allowlisting, kubelet rejects the pods with `SysctlForbidden`, so LoadBalancer services never get a working data plane (`EXTERNAL-IP` stays `<pending>`).

## Scope

`deploy/kubelet.go` only; affects newly deployed/repaired worker nodes.

## Verification

Reproduced `SysctlForbidden` on a local worker, applied the allowlist, rebuilt the svclb pod → 2/2 Running; dashboard healthy.