### PR TITLE
fix: grant helper pod DAC_OVERRIDE to delete volume data

### DIFF
--- a/server/storage_bootstrap.go
+++ b/server/storage_bootstrap.go
@@ -188,6 +188,8 @@ spec:
         capabilities:
           drop:
             - ALL
+          add:
+            - DAC_OVERRIDE
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
## What

Add `DAC_OVERRIDE` to the local-path helper pod's capabilities in the generated `helperPod.yaml` (server/storage_bootstrap.go).

## Why

The helper pod runs as root (`runAsUser: 0`) with `capabilities.drop: [ALL]`. Without `CAP_DAC_OVERRIDE`, root still obeys standard file permission checks. When an app writes volume data as a non-root user (e.g. Bitnami images running as UID 1001), teardown fails with `Permission denied` when removing files inside a 755 directory owned by that UID. The PVC stays stuck in `Terminating` and orphaned volume directories remain on disk.

Refs #121

## Scope

`server/storage_bootstrap.go` only — the generated helper pod spec. Affects newly bootstrapped control planes (helper pods created after this change).

## Verification

Reproduced the failure locally (Grafana volume teardown, UID 1001 files, `rm` exited 1), applied the capability via the live `local-path-config` ConfigMap, and confirmed the orphaned volume directory was deleted and the helper pod exited successfully.