### PR TITLE
fix: fall back to canonical registry when mirror fails

### DIFF
--- a/deploy/containerd_config.go
+++ b/deploy/containerd_config.go
@@ -24,20 +24,25 @@ version = 2
 }
 
 // GenerateDockerHubHostsToml returns the content for
-// /etc/containerd/certs.d/docker.io/hosts.toml. The canonical server remains
-// the fallback when the mirror is unavailable.
+// /etc/containerd/certs.d/docker.io/hosts.toml. The canonical server is
+// listed as an explicit host so pull falls back to it when the mirror is
+// unavailable (containerd does not fall back to the server field itself).
 func GenerateDockerHubHostsToml() string {
 	return generatedRegistryHostsMarker + `
 server = "https://registry-1.docker.io"
 
 [host."https://docker.1ms.run"]
   capabilities = ["pull", "resolve"]
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
 `
 }
 
 // GenerateK8sRegistryHostsToml returns the content for
-// /etc/containerd/certs.d/registry.k8s.io/hosts.toml. The canonical server
-// remains the fallback when the mirror is unavailable.
+// /etc/containerd/certs.d/registry.k8s.io/hosts.toml. The canonical server is
+// listed as an explicit host so pull falls back to it when the mirror is
+// unavailable.
 func GenerateK8sRegistryHostsToml() string {
 	return generatedRegistryHostsMarker + `
 server = "https://registry.k8s.io"
@@ -45,6 +50,9 @@ server = "https://registry.k8s.io"
 [host."https://registry.aliyuncs.com/v2/google_containers"]
   capabilities = ["pull", "resolve"]
   override_path = true
+
+[host."https://registry.k8s.io"]
+  capabilities = ["pull", "resolve"]
 `
 }
 
@@ -53,6 +61,9 @@ func legacyDockerHubHostsToml() string {
 
 [host."https://docker.1ms.run"]
   capabilities = ["pull", "resolve"]
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
 `
 }
 
@@ -60,6 +71,9 @@ func legacyK8sRegistryHostsToml() string {
 	return `server = "https://registry.k8s.io"
 
 [host."https://registry.aliyuncs.com/google_containers"]
+  capabilities = ["pull", "resolve"]
+
+[host."https://registry.k8s.io"]
   capabilities = ["pull", "resolve"]
 `
 }


### PR DESCRIPTION
## What

Add the canonical registry as an explicit `[host."..."]` entry in the hosts.toml files generated by `GenerateDockerHubHostsToml`, `GenerateK8sRegistryHostsToml`, and their `legacy*` counterparts (deploy/containerd_config.go). When the configured mirror is unavailable, containerd now falls back to the canonical server and the pull succeeds.

## Why

In containerd's hosts.toml semantics, the `server =` field is only a declaration of which registry the file serves; it does not participate in pull attempts. Only entries under `[host."..."]` are tried. The previous templates listed just the mirror as a host, so when the mirror failed (e.g. EOF from an unstable accelerator), the pull had no fallback and hung forever. The code comment claiming "the canonical server remains the fallback" was incorrect.

## Scope

`deploy/containerd_config.go` only. Affects worker nodes deployed/repaired after this change; existing nodes keep their old hosts.toml until re-deployed.

## Verification

On a live worker, pointed the mirror at an unreachable address (127.0.0.1:1) and confirmed via containerd logs that the pull fell back to `registry-1.docker.io` and succeeded ("trying next host" logged, image pulled). With the healthy mirror restored, pulls still use the mirror first.