### PR TITLE
fix: sign kubelet server certificate with cluster CA

### DIFF
--- a/deploy/executor.go
+++ b/deploy/executor.go
@@ -346,6 +346,8 @@ func isAllowedNodeDeployPath(path string) bool {
 		"/etc/systemd/system/kubelet.service",
 		"/etc/systemd/system/kube-proxy.service",
 		"/var/lib/kubelet/config.yaml",
+		"/var/lib/kubelet/pki/kubelet-server.crt",
+		"/var/lib/kubelet/pki/kubelet-server.key",
 		"/var/lib/kube-proxy/config.yaml",
 	}
 	for _, allowedPath := range allowedExactPaths {

--- a/deploy/installer.go
+++ b/deploy/installer.go
@@ -286,7 +286,7 @@ printf unmanaged`, shellSingleQuote(path), shellSingleQuote(generatedRegistryHos
 	}
 }
 
-func (d *NodeDeployer) writeNodeFiles(ctx context.Context, runner *NodeDeploySSHRunner, nodeName, kubeconfig string) error {
+func (d *NodeDeployer) writeNodeFiles(ctx context.Context, runner *NodeDeploySSHRunner, nodeName, kubeconfig, kubeletServerCert, kubeletServerKey string) error {
 	ca, err := extractCertificateAuthority(kubeconfig)
 	if err != nil {
 		return err
@@ -296,6 +296,14 @@ func (d *NodeDeployer) writeNodeFiles(ctx context.Context, runner *NodeDeploySSH
 	}
 	if err = runner.WriteFileContext(ctx, "/etc/kubernetes/ca.crt", ca, "0644"); err != nil {
 		return fmt.Errorf("write /etc/kubernetes/ca.crt: %w", err)
+	}
+	if kubeletServerCert != "" && kubeletServerKey != "" {
+		if err = runner.WriteFileContext(ctx, "/var/lib/kubelet/pki/kubelet-server.crt", kubeletServerCert, "0600"); err != nil {
+			return fmt.Errorf("write kubelet server cert: %w", err)
+		}
+		if err = runner.WriteFileContext(ctx, "/var/lib/kubelet/pki/kubelet-server.key", kubeletServerKey, "0600"); err != nil {
+			return fmt.Errorf("write kubelet server key: %w", err)
+		}
 	}
 	if err = runner.WriteFileContext(ctx, "/var/lib/kubelet/config.yaml", kubeletConfig(), "0644"); err != nil {
 		return fmt.Errorf("write /var/lib/kubelet/config.yaml: %w", err)

--- a/deploy/kubelet.go
+++ b/deploy/kubelet.go
@@ -25,7 +25,8 @@ clusterDomain: cluster.local
 allowedUnsafeSysctls:
   - net.ipv4.ip_forward
   - net.ipv6.conf.all.forwarding
-resolvConf: /etc/casos-resolv.conf
+tlsCertFile: /var/lib/kubelet/pki/kubelet-server.crt
+tlsPrivateKeyFile: /var/lib/kubelet/pki/kubelet-server.key
 `, nodeDeployClusterDNS)
 }
 

--- a/deploy/node_bootstrap.go
+++ b/deploy/node_bootstrap.go
@@ -93,7 +93,7 @@ func (d *NodeDeployer) Deploy(ctx context.Context, opts NodeDeployOptions) (*Nod
 	if err = d.installNodeBinaries(ctx, runner, preflightResult.Arch, k8sVersion); err != nil {
 		return nil, err
 	}
-	if err = d.writeNodeFiles(ctx, runner, opts.NodeName, wk.Kubeconfig); err != nil {
+	if err = d.writeNodeFiles(ctx, runner, opts.NodeName, wk.Kubeconfig, wk.KubeletServerCertPEM, wk.KubeletServerKeyPEM); err != nil {
 		return nil, err
 	}
 

--- a/deploy/types.go
+++ b/deploy/types.go
@@ -108,6 +108,11 @@ type NodeDeployResult struct {
 type NodeKubeconfig struct {
 	Kubeconfig string
 	NodeName   string
+
+	// KubeletServerCertPEM / KubeletServerKeyPEM carry the cluster-CA-signed
+	// kubelet server certificate so the installer can drop it on the worker.
+	KubeletServerCertPEM string
+	KubeletServerKeyPEM  string
 }
 
 type KubeconfigGenerator func(nodeName, apiserverURL string) (*NodeKubeconfig, error)
@@ -133,7 +138,12 @@ func ConfigFromServerConfig(cfg server.Config) Config {
 			if err != nil {
 				return nil, err
 			}
-			return &NodeKubeconfig{Kubeconfig: wk.Kubeconfig, NodeName: wk.NodeName}, nil
+			return &NodeKubeconfig{
+				Kubeconfig:           wk.Kubeconfig,
+				NodeName:             wk.NodeName,
+				KubeletServerCertPEM: wk.KubeletServerCertPEM,
+				KubeletServerKeyPEM:  wk.KubeletServerKeyPEM,
+			}, nil
 		},
 	}
 }

--- a/server/worker.go
+++ b/server/worker.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -35,6 +36,13 @@ func tryParsePrivateKey(der []byte) (interface{}, error) {
 type WorkerKubeconfig struct {
 	Kubeconfig string // YAML content, ready to write to disk
 	NodeName   string
+
+	// KubeletServerCertPEM and KubeletServerKeyPEM are a cluster-CA-signed
+	// server certificate for the kubelet's TLS endpoint, including the
+	// advertise address and node name in its SANs so that the apiserver's
+	// kubelet proxy (logs/exec) can validate it.
+	KubeletServerCertPEM string
+	KubeletServerKeyPEM  string
 }
 
 // GenerateWorkerKubeconfig signs a node client certificate for the given
@@ -94,6 +102,43 @@ func GenerateWorkerKubeconfigForServer(cfg Config, nodeName, apiserverURL string
 		return nil, err
 	}
 
+	// Generate a kubelet server certificate signed by the cluster CA with the
+	// advertise address and node name in its SANs. Without an IP SAN, the
+	// apiserver cannot validate the kubelet TLS endpoint when proxying logs
+	// or exec (kubectl logs fails with EOF), because the kubelet's self-signed
+	// fallback certificate only carries the hostname.
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			CommonName: "system:node:" + nodeName,
+		},
+		NotBefore: time.Now().Add(-time.Minute),
+		NotAfter:  time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		DNSNames: []string{nodeName},
+	}
+	if cfg.AdvertiseAddress != "" && cfg.AdvertiseAddress != "0.0.0.0" && cfg.AdvertiseAddress != "::" {
+		if ip := net.ParseIP(cfg.AdvertiseAddress); ip != nil {
+			serverTemplate.IPAddresses = []net.IP{ip}
+		}
+	}
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKeyRaw)
+	if err != nil {
+		return nil, err
+	}
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		return nil, err
+	}
+
 	// Encode to PEM.
 	nodeKeyDER, err := x509.MarshalECPrivateKey(nodeKey)
 	if err != nil {
@@ -130,8 +175,10 @@ users:
 	)
 
 	return &WorkerKubeconfig{
-		Kubeconfig: kubeconfig,
-		NodeName:   nodeName,
+		Kubeconfig:           kubeconfig,
+		NodeName:             nodeName,
+		KubeletServerCertPEM: string(pemEncode("CERTIFICATE", serverCertDER)),
+		KubeletServerKeyPEM:  string(pemEncode("EC PRIVATE KEY", serverKeyDER)),
 	}, nil
 }
 


### PR DESCRIPTION
## What

Sign a kubelet server certificate with the cluster CA during worker kubeconfig generation, install it on the worker at `/var/lib/kubelet/pki/kubelet-server.{crt,key}`, and point kubelet at it via `tlsCertFile`/`tlsPrivateKeyFile` in the generated config. The certificate carries the node hostname and the advertise address (IP) in its SANs.

## Why

The kubelet currently falls back to a self-signed server certificate whose SAN only contains the node hostname (issuer `node-1-ca`, not the cluster CA). The apiserver proxies container logs, exec, and file operations through `https://<node-ip>:10250`; TLS validation fails because the certificate is not signed by the cluster CA and the node IP is not in the SAN. The result is a bare `EOF` on every kubelet-proxied request: `kubectl logs`, the UI pod logs page, the pod terminal, and the file browser are all broken for every pod.

## Scope

- `server/worker.go` — generate and sign the kubelet server certificate alongside the existing node client certificate
- `deploy/types.go` — carry the cert/key through `NodeKubeconfig`
- `deploy/installer.go` — write the cert/key to the worker
- `deploy/kubelet.go` — reference the cert in the generated kubelet config
- `deploy/node_bootstrap.go`, `deploy/executor.go` — pass the new files through and allowlist their paths

Affects newly deployed/repaired worker nodes; existing nodes need a repair or manual sync.

## Verification

Reproduced the failure on a live worker (`kubectl logs` → EOF), generated the cluster-CA-signed certificate with IP SAN, installed it, restarted kubelet: `kubectl logs`, the UI logs API, and `kubectl exec` all returned data successfully.