### PR TITLE
feat: add helm operation cancellation

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -437,6 +437,35 @@ type helmUninstallReq struct {
 	Namespace   string `json:"namespace"`
 }
 
+// CancelHelmOperation requests cancellation of a running Helm operation task.
+// @router /api/cancel-helm-operation [post]
+func (c *ApiController) CancelHelmOperation() {
+	if c.RequireAdmin() {
+		return
+	}
+	var req struct {
+		TaskID int64 `json:"taskId"`
+	}
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &req); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if req.TaskID <= 0 {
+		c.ResponseError("invalid task id")
+		return
+	}
+	task, err := object.GetHelmOperationTaskForOwner(req.TaskID, helmOperationOwner(c))
+	if err != nil || task == nil {
+		c.ResponseError("Helm operation task not found")
+		return
+	}
+	if err := object.RequestHelmOperationCancel(req.TaskID); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk()
+}
+
 // UninstallHelmRelease removes a Helm release from the cluster.
 // @router /api/uninstall-helm-release [post]
 func (c *ApiController) UninstallHelmRelease() {

--- a/object/helm_operation.go
+++ b/object/helm_operation.go
@@ -265,6 +265,19 @@ func FinishHelmOperationTaskContext(ctx context.Context, id int64, success bool,
 		phase = HelmOperationPhaseFailed
 	}
 	now := time.Now().UTC()
+	// A task whose cancel was already requested finishes as cancelled, not
+	// failed, so callers can tell a user cancellation from an install error.
+	if !success {
+		task := &HelmOperationTask{Id: id}
+		found, err := ormer.Engine.Context(ctx).Get(task)
+		if err != nil {
+			return err
+		}
+		if found && task.Status == HelmOperationStatusCancelling {
+			status = HelmOperationStatusCancelled
+			phase = HelmOperationPhaseFailed
+		}
+	}
 	affected, err := ormer.Engine.Context(ctx).ID(id).
 		Where("status IN (?, ?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning, HelmOperationStatusCancelling).
 		Cols("active_key", "status", "phase", "error_msg", "finished_at", "updated_at").

--- a/object/helm_operation.go
+++ b/object/helm_operation.go
@@ -14,10 +14,10 @@ import (
 const (
 	HelmOperationInstall = "install"
 
-	HelmOperationStatusPending   = "pending"
-	HelmOperationStatusRunning   = "running"
-	HelmOperationStatusSucceeded = "succeeded"
-	HelmOperationStatusFailed    = "failed"
+	HelmOperationStatusPending    = "pending"
+	HelmOperationStatusRunning    = "running"
+	HelmOperationStatusSucceeded  = "succeeded"
+	HelmOperationStatusFailed     = "failed"
 	HelmOperationStatusCancelling = "cancelling"
 	HelmOperationStatusCancelled  = "cancelled"
 

--- a/object/helm_operation.go
+++ b/object/helm_operation.go
@@ -18,6 +18,8 @@ const (
 	HelmOperationStatusRunning   = "running"
 	HelmOperationStatusSucceeded = "succeeded"
 	HelmOperationStatusFailed    = "failed"
+	HelmOperationStatusCancelling = "cancelling"
+	HelmOperationStatusCancelled  = "cancelled"
 
 	HelmOperationPhaseQueued     = "queued"
 	HelmOperationPhaseLoading    = "loading"
@@ -222,6 +224,34 @@ func UpdateHelmOperationTaskPhaseContext(ctx context.Context, id int64, phase st
 
 func FinishHelmOperationTask(id int64, success bool, errorMsg string) error {
 	return FinishHelmOperationTaskContext(context.Background(), id, success, errorMsg)
+}
+
+// RequestHelmOperationCancel marks a running task as cancelling; the installer
+// goroutine polls this state and aborts the Helm operation.
+func RequestHelmOperationCancel(id int64) error {
+	affected, err := ormer.Engine.ID(id).
+		Where("status = ?", HelmOperationStatusRunning).
+		Cols("status", "updated_at").
+		Update(&HelmOperationTask{Status: HelmOperationStatusCancelling, UpdatedAt: time.Now().UTC()})
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("Helm operation task %d is not running", id)
+	}
+	return nil
+}
+
+func HelmOperationTaskIsCancelling(id int64) (bool, error) {
+	task := &HelmOperationTask{Id: id}
+	found, err := ormer.Engine.Get(task)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	return task.Status == HelmOperationStatusCancelling, nil
 }
 
 func FinishHelmOperationTaskContext(ctx context.Context, id int64, success bool, errorMsg string) error {

--- a/object/helm_operation.go
+++ b/object/helm_operation.go
@@ -195,7 +195,7 @@ func StartHelmOperationTaskContext(ctx context.Context, id int64, phase string) 
 
 func TouchHelmOperationTaskContext(ctx context.Context, id int64) error {
 	_, err := ormer.Engine.Context(ctx).ID(id).
-		Where("status IN (?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning).
+		Where("status IN (?, ?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning, HelmOperationStatusCancelling).
 		Cols("updated_at").
 		Update(&HelmOperationTask{UpdatedAt: time.Now().UTC()})
 	return err
@@ -210,7 +210,7 @@ func UpdateHelmOperationTaskPhaseContext(ctx context.Context, id int64, phase st
 		return fmt.Errorf("invalid Helm operation phase: %s", phase)
 	}
 	affected, err := ormer.Engine.Context(ctx).ID(id).
-		Where("status = ? AND phase = ?", HelmOperationStatusRunning, HelmOperationPhaseLoading).
+		Where("status IN (?, ?) AND phase = ?", HelmOperationStatusRunning, HelmOperationStatusCancelling, HelmOperationPhaseLoading).
 		Cols("phase", "updated_at").
 		Update(&HelmOperationTask{Phase: phase, UpdatedAt: time.Now().UTC()})
 	if err != nil {
@@ -300,7 +300,8 @@ func HelmOperationTaskHasTerminalOutcomeContext(ctx context.Context, id int64, s
 	if success {
 		return task.Status == HelmOperationStatusSucceeded && task.Phase == HelmOperationPhaseReady && task.ErrorMsg == "", nil
 	}
-	return task.Status == HelmOperationStatusFailed && task.Phase == HelmOperationPhaseFailed && task.ErrorMsg == errorMsg, nil
+	return (task.Status == HelmOperationStatusFailed || task.Status == HelmOperationStatusCancelled) &&
+		task.Phase == HelmOperationPhaseFailed && task.ErrorMsg == errorMsg, nil
 }
 
 func addHelmOperationLogs(taskID int64, logs []*HelmOperationLog) error {
@@ -325,7 +326,7 @@ func addHelmOperationLogsContext(ctx context.Context, taskID int64, logs []*Helm
 			return nil, err
 		}
 		_, err := session.ID(taskID).
-			Where("status IN (?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning).
+			Where("status IN (?, ?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning, HelmOperationStatusCancelling).
 			Cols("updated_at").
 			Update(&HelmOperationTask{UpdatedAt: now})
 		return nil, err

--- a/object/helm_operation.go
+++ b/object/helm_operation.go
@@ -266,7 +266,7 @@ func FinishHelmOperationTaskContext(ctx context.Context, id int64, success bool,
 	}
 	now := time.Now().UTC()
 	affected, err := ormer.Engine.Context(ctx).ID(id).
-		Where("status IN (?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning).
+		Where("status IN (?, ?, ?)", HelmOperationStatusPending, HelmOperationStatusRunning, HelmOperationStatusCancelling).
 		Cols("active_key", "status", "phase", "error_msg", "finished_at", "updated_at").
 		Update(&HelmOperationTask{ActiveKey: nil, Status: status, Phase: phase, ErrorMsg: errorMsg, FinishedAt: now, UpdatedAt: now})
 	if err != nil {

--- a/object/helm_operation_recorder.go
+++ b/object/helm_operation_recorder.go
@@ -23,6 +23,7 @@ const (
 	helmOperationFinishAttempts    = 3
 	helmOperationFinishRetryDelay  = 100 * time.Millisecond
 	helmOperationHeartbeatInterval = time.Minute
+	helmOperationCancelPollInterval = time.Second
 )
 
 type HelmOperationRecorder struct {
@@ -48,6 +49,8 @@ type HelmOperationRecorder struct {
 	finishRetryDelay  time.Duration
 	persistCtx        context.Context
 	cancelPersist     context.CancelFunc
+	cancelCh          chan struct{}
+	cancelPollOnce    sync.Once
 }
 
 func NewHelmOperationRecorder(taskID int64) *HelmOperationRecorder {
@@ -56,6 +59,7 @@ func NewHelmOperationRecorder(taskID int64) *HelmOperationRecorder {
 		taskID:            taskID,
 		queue:             make(chan *HelmOperationLog, helmOperationLogBatchSize*2),
 		done:              make(chan struct{}),
+		cancelCh:          make(chan struct{}),
 		persistLogs:       addHelmOperationLogsContext,
 		finishTask:        FinishHelmOperationTaskContext,
 		terminalMatches:   HelmOperationTaskHasTerminalOutcomeContext,
@@ -69,7 +73,35 @@ func NewHelmOperationRecorder(taskID int64) *HelmOperationRecorder {
 		cancelPersist:     cancelPersist,
 	}
 	go recorder.run()
+	go recorder.pollCancel()
 	return recorder
+}
+
+// Cancelled returns a channel closed when a cancel has been requested for
+// the underlying task. The installer selects on it to abort the Helm run.
+func (r *HelmOperationRecorder) Cancelled() <-chan struct{} {
+	return r.cancelCh
+}
+
+func (r *HelmOperationRecorder) pollCancel() {
+	ticker := time.NewTicker(helmOperationCancelPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.persistCtx.Done():
+			return
+		case <-ticker.C:
+			cancelling, err := HelmOperationTaskIsCancelling(r.taskID)
+			if err != nil {
+				logs.Warning("poll Helm operation task %d cancel state: %v", r.taskID, err)
+				continue
+			}
+			if cancelling {
+				r.cancelPollOnce.Do(func() { close(r.cancelCh) })
+				return
+			}
+		}
+	}
 }
 
 func (r *HelmOperationRecorder) StartLoading() error {

--- a/object/helm_operation_recorder.go
+++ b/object/helm_operation_recorder.go
@@ -13,16 +13,16 @@ import (
 )
 
 const (
-	helmOperationLogBatchSize      = 50
-	helmOperationLogFlushInterval  = 200 * time.Millisecond
-	helmOperationLogEnqueueTimeout = 2 * time.Second
-	helmOperationLogPersistTimeout = HelmOperationPersistenceTimeout
-	helmOperationRecorderShutdown  = 3*helmOperationLogPersistTimeout + time.Second
-	helmOperationRecorderStopGrace = 100 * time.Millisecond
-	helmOperationFinishTimeout     = HelmOperationPersistenceTimeout
-	helmOperationFinishAttempts    = 3
-	helmOperationFinishRetryDelay  = 100 * time.Millisecond
-	helmOperationHeartbeatInterval = time.Minute
+	helmOperationLogBatchSize       = 50
+	helmOperationLogFlushInterval   = 200 * time.Millisecond
+	helmOperationLogEnqueueTimeout  = 2 * time.Second
+	helmOperationLogPersistTimeout  = HelmOperationPersistenceTimeout
+	helmOperationRecorderShutdown   = 3*helmOperationLogPersistTimeout + time.Second
+	helmOperationRecorderStopGrace  = 100 * time.Millisecond
+	helmOperationFinishTimeout      = HelmOperationPersistenceTimeout
+	helmOperationFinishAttempts     = 3
+	helmOperationFinishRetryDelay   = 100 * time.Millisecond
+	helmOperationHeartbeatInterval  = time.Minute
 	helmOperationCancelPollInterval = time.Second
 )
 

--- a/object/helm_operation_recorder.go
+++ b/object/helm_operation_recorder.go
@@ -135,14 +135,16 @@ func (r *HelmOperationRecorder) RecordLog(line string) error {
 		return fmt.Errorf("Helm operation recorder is closed")
 	}
 	r.writers.Add(1)
-	r.mu.Unlock()
-	defer r.writers.Done()
 	timer := time.NewTimer(helmOperationLogEnqueueTimeout)
 	defer timer.Stop()
 	select {
 	case r.queue <- entry:
+		r.writers.Done()
+		r.mu.Unlock()
 		return nil
 	case <-timer.C:
+		r.writers.Done()
+		r.mu.Unlock()
 		return fmt.Errorf("Helm operation log queue is full")
 	}
 }
@@ -151,10 +153,9 @@ func (r *HelmOperationRecorder) Finish(installErr error) error {
 	r.finish.Do(func() {
 		r.mu.Lock()
 		r.closed = true
-		r.mu.Unlock()
-
 		r.writers.Wait()
 		close(r.queue)
+		r.mu.Unlock()
 		shutdownTimer := time.NewTimer(r.shutdownTimeout)
 		select {
 		case <-r.done:

--- a/object/helm_operation_recorder.go
+++ b/object/helm_operation_recorder.go
@@ -135,16 +135,14 @@ func (r *HelmOperationRecorder) RecordLog(line string) error {
 		return fmt.Errorf("Helm operation recorder is closed")
 	}
 	r.writers.Add(1)
+	r.mu.Unlock()
+	defer r.writers.Done()
 	timer := time.NewTimer(helmOperationLogEnqueueTimeout)
 	defer timer.Stop()
 	select {
 	case r.queue <- entry:
-		r.writers.Done()
-		r.mu.Unlock()
 		return nil
 	case <-timer.C:
-		r.writers.Done()
-		r.mu.Unlock()
 		return fmt.Errorf("Helm operation log queue is full")
 	}
 }
@@ -153,9 +151,9 @@ func (r *HelmOperationRecorder) Finish(installErr error) error {
 	r.finish.Do(func() {
 		r.mu.Lock()
 		r.closed = true
+		r.mu.Unlock()
 		r.writers.Wait()
 		close(r.queue)
-		r.mu.Unlock()
 		shutdownTimer := time.NewTimer(r.shutdownTimeout)
 		select {
 		case <-r.done:

--- a/object/helm_operation_test.go
+++ b/object/helm_operation_test.go
@@ -1,0 +1,119 @@
+package object
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+	"xorm.io/xorm"
+)
+
+func newHelmOperationTestEngine(t *testing.T) *xorm.Engine {
+	t.Helper()
+	engine, err := xorm.NewEngine("sqlite", "file:helm_operation_test?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open test sqlite engine: %v", err)
+	}
+	t.Cleanup(func() { _ = engine.Close() })
+	engine.SetMaxOpenConns(1)
+	if err := engine.Sync2(new(HelmOperationTask), new(HelmOperationLog)); err != nil {
+		t.Fatalf("sync test schema: %v", err)
+	}
+	return engine
+}
+
+func insertTestHelmOperationTask(t *testing.T, status, phase string) int64 {
+	t.Helper()
+	task := &HelmOperationTask{
+		Operation: "install", ReleaseName: "demo", Namespace: "default",
+		ChartName: "demo-chart", Status: status, Phase: phase,
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	if _, err := ormer.Engine.Insert(task); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+	return task.Id
+}
+
+func TestHelmOperationCancelFlow(t *testing.T) {
+	prevOrmer := ormer
+	ormer = &Ormer{Engine: newHelmOperationTestEngine(t)}
+	defer func() { ormer = prevOrmer }()
+	ctx := context.Background()
+	id := insertTestHelmOperationTask(t, HelmOperationStatusPending, HelmOperationPhaseQueued)
+
+	if err := StartHelmOperationTaskContext(ctx, id, HelmOperationPhaseLoading); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	if err := RequestHelmOperationCancel(id); err != nil {
+		t.Fatalf("request cancel: %v", err)
+	}
+	if err := UpdateHelmOperationTaskPhaseContext(ctx, id, HelmOperationPhaseInstalling); err != nil {
+		t.Fatalf("mark installing during cancelling should not error: %v", err)
+	}
+	if err := TouchHelmOperationTaskContext(ctx, id); err != nil {
+		t.Fatalf("touch during cancelling: %v", err)
+	}
+	if err := FinishHelmOperationTaskContext(ctx, id, false, "install cancelled by user"); err != nil {
+		t.Fatalf("finish cancelled task: %v", err)
+	}
+	final := &HelmOperationTask{Id: id}
+	if found, err := ormer.Engine.Get(final); err != nil || !found {
+		t.Fatalf("get task: found=%v err=%v", found, err)
+	}
+	if final.Status != HelmOperationStatusCancelled || final.Phase != HelmOperationPhaseFailed || final.ErrorMsg != "install cancelled by user" {
+		t.Fatalf("unexpected terminal state: status=%q phase=%q error=%q", final.Status, final.Phase, final.ErrorMsg)
+	}
+	matched, err := HelmOperationTaskHasTerminalOutcomeContext(ctx, id, false, "install cancelled by user")
+	if err != nil || !matched {
+		t.Fatalf("terminal outcome should match cancelled task: matched=%v err=%v", matched, err)
+	}
+}
+
+func TestHelmOperationLogsDuringCancelling(t *testing.T) {
+	prevOrmer := ormer
+	ormer = &Ormer{Engine: newHelmOperationTestEngine(t)}
+	defer func() { ormer = prevOrmer }()
+	ctx := context.Background()
+	id := insertTestHelmOperationTask(t, HelmOperationStatusPending, HelmOperationPhaseQueued)
+	if err := StartHelmOperationTaskContext(ctx, id, HelmOperationPhaseLoading); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	if err := RequestHelmOperationCancel(id); err != nil {
+		t.Fatalf("request cancel: %v", err)
+	}
+	entries := []*HelmOperationLog{{
+		TaskId: id, Level: HelmOperationLogLevelInfo,
+		Message: "still logging during cancelling", CreatedAt: time.Now().UTC(),
+	}}
+	if err := addHelmOperationLogsContext(ctx, id, entries); err != nil {
+		t.Fatalf("persist logs during cancelling: %v", err)
+	}
+	logs, err := GetHelmOperationLogs(id, 10)
+	if err != nil || len(logs) != 1 || logs[0].Message != "still logging during cancelling" {
+		t.Fatalf("unexpected logs: len=%d err=%v", len(logs), err)
+	}
+}
+
+func TestHelmOperationRecorderCancelPoll(t *testing.T) {
+	prevOrmer := ormer
+	ormer = &Ormer{Engine: newHelmOperationTestEngine(t)}
+	defer func() { ormer = prevOrmer }()
+	id := insertTestHelmOperationTask(t, HelmOperationStatusPending, HelmOperationPhaseQueued)
+	rec := NewHelmOperationRecorder(id)
+	defer func() {
+		_ = rec.Finish(nil)
+	}()
+	if err := rec.StartLoading(); err != nil {
+		t.Fatalf("start loading: %v", err)
+	}
+	if err := RequestHelmOperationCancel(id); err != nil {
+		t.Fatalf("request cancel: %v", err)
+	}
+	select {
+	case <-rec.Cancelled():
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancel channel not closed within 5s")
+	}
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -151,6 +151,7 @@ func InitAPI() {
 	beego.Router("/api/install-helm-chart", &controllers.ApiController{}, "POST:InstallHelmChart")
 	beego.Router("/api/install-helm-chart-stream", &controllers.ApiController{}, "POST:InstallHelmChartStream")
 	beego.Router("/api/get-helm-operation-task", &controllers.ApiController{}, "GET:GetHelmOperationTask")
+	beego.Router("/api/cancel-helm-operation", &controllers.ApiController{}, "POST:CancelHelmOperation")
 	beego.Router("/api/upgrade-helm-release", &controllers.ApiController{}, "POST:UpgradeHelmRelease")
 	beego.Router("/api/rollback-helm-release", &controllers.ApiController{}, "POST:RollbackHelmRelease")
 	beego.Router("/api/uninstall-helm-release", &controllers.ApiController{}, "POST:UninstallHelmRelease")

--- a/store/helm.go
+++ b/store/helm.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -1364,6 +1365,13 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		return eventCh
 	}
 	go func() {
+		var streamClosedOnce sync.Once
+		streamClosed := make(chan struct{})
+		defer func() {
+			// Signal concurrent senders (e.g. a Helm wait callback) to stop
+			// before eventCh is closed, so they exit without panicking.
+			streamClosedOnce.Do(func() { close(streamClosed) })
+		}()
 		defer close(eventCh)
 		streamCtx := ctx
 		if streamCtx == nil {
@@ -1383,15 +1391,14 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 				}
 			}
 			defer func() {
-				// A concurrent sender (e.g. a Helm wait callback) may still
-				// emit after this goroutine's deferred close(eventCh) ran on
-				// the cancel path; swallow the send to a closed channel.
 				_ = recover()
 			}()
 			select {
 			case eventCh <- event:
 				return true
 			case <-streamCtx.Done():
+				return false
+			case <-streamClosed:
 				return false
 			}
 		}
@@ -1407,8 +1414,13 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		finishWithError := func(err error, step string) {
 			if errors.Is(err, context.Canceled) {
 				sendLog("ABORTED: install cancelled by user")
+				sendLog("WARNING: resources already created may remain; uninstall them from the Helm Releases page if needed")
 				if finishErr := lifecycle.Finish(fmt.Errorf("install cancelled by user")); finishErr != nil {
 					logrus.Errorf("failed to finish Helm operation after %s: %v", step, finishErr)
+				}
+				select {
+				case eventCh <- HelmInstallStreamEvent{Type: HelmInstallStreamEventDone}:
+				case <-streamCtx.Done():
 				}
 				return
 			}
@@ -1492,7 +1504,13 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		if installErr != nil {
 			if errors.Is(installErr, context.Canceled) {
 				sendLog("ABORTED: install cancelled by user")
+				sendLog("WARNING: resources already created may remain; uninstall them from the Helm Releases page if needed")
+				_ = cleanupFailedHelmRelease(actionConfig, install, failedRelease)
 				_ = lifecycle.Finish(fmt.Errorf("install cancelled by user"))
+				select {
+				case eventCh <- HelmInstallStreamEvent{Type: HelmInstallStreamEventDone}:
+				case <-streamCtx.Done():
+				}
 				return
 			}
 			err = finishFailedHelmInstall(

--- a/store/helm.go
+++ b/store/helm.go
@@ -1382,6 +1382,12 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 					logrus.Warnf("failed to persist Helm operation log: %v", err)
 				}
 			}
+			defer func() {
+				// A concurrent sender (e.g. a Helm wait callback) may still
+				// emit after this goroutine's deferred close(eventCh) ran on
+				// the cancel path; swallow the send to a closed channel.
+				_ = recover()
+			}()
 			select {
 			case eventCh <- event:
 				return true

--- a/store/helm.go
+++ b/store/helm.go
@@ -1404,10 +1404,17 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		sendError := func(err error) bool {
 			return send(newHelmErrorEvent(err))
 		}
-		finishWithError := func(err error, context string) {
+		finishWithError := func(err error, step string) {
+			if errors.Is(err, context.Canceled) {
+				sendLog("ABORTED: install cancelled by user")
+				if finishErr := lifecycle.Finish(fmt.Errorf("install cancelled by user")); finishErr != nil {
+					logrus.Errorf("failed to finish Helm operation after %s: %v", step, finishErr)
+				}
+				return
+			}
 			sendError(err)
 			if finishErr := lifecycle.Finish(err); finishErr != nil {
-				logrus.Errorf("failed to finish Helm operation after %s: %v", context, finishErr)
+				logrus.Errorf("failed to finish Helm operation after %s: %v", step, finishErr)
 			}
 		}
 		if err := lifecycle.StartLoading(); err != nil {
@@ -1424,6 +1431,18 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 			helmInstallOperationDeadline(installTimeout),
 		)
 		defer cancelInstall()
+		// Watch for cancellation from the very start of the install: the task
+		// is already running during chart loading and compatibility checks, and
+		// cancelInstall() aborts every stage derived from installCtx.
+		cancelWatcher := make(chan struct{})
+		go func() {
+			select {
+			case <-lifecycle.Cancelled():
+				cancelInstall()
+			case <-cancelWatcher:
+			}
+		}()
+		defer close(cancelWatcher)
 		logFn := func(format string, args ...interface{}) {
 			sendLog(fmt.Sprintf(format, args...))
 		}
@@ -1469,16 +1488,7 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		}
 		install := action.NewInstall(actionConfig)
 		configureHelmInstall(install, releaseName, namespace, installTimeout)
-		cancelWatcher := make(chan struct{})
-		go func() {
-			select {
-			case <-lifecycle.Cancelled():
-				cancelInstall()
-			case <-cancelWatcher:
-			}
-		}()
 		failedRelease, installErr := install.RunWithContext(installCtx, helmChart, vals)
-		close(cancelWatcher)
 		if installErr != nil {
 			if errors.Is(installErr, context.Canceled) {
 				sendLog("ABORTED: install cancelled by user")

--- a/store/helm.go
+++ b/store/helm.go
@@ -1319,6 +1319,9 @@ type HelmInstallLifecycle interface {
 	MarkInstalling() error
 	RecordLog(line string) error
 	Finish(installErr error) error
+	// Cancelled returns a channel closed when the task has been requested
+	// to cancel; the installer aborts the Helm run when it fires.
+	Cancelled() <-chan struct{}
 }
 
 const (
@@ -1460,8 +1463,22 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 		}
 		install := action.NewInstall(actionConfig)
 		configureHelmInstall(install, releaseName, namespace, installTimeout)
+		cancelWatcher := make(chan struct{})
+		go func() {
+			select {
+			case <-lifecycle.Cancelled():
+				cancelInstall()
+			case <-cancelWatcher:
+			}
+		}()
 		failedRelease, installErr := install.RunWithContext(installCtx, helmChart, vals)
+		close(cancelWatcher)
 		if installErr != nil {
+			if errors.Is(installErr, context.Canceled) {
+				sendLog("ABORTED: install cancelled by user")
+				_ = lifecycle.Finish(fmt.Errorf("install cancelled by user"))
+				return
+			}
 			err = finishFailedHelmInstall(
 				installErr,
 				func(installErr error) error {


### PR DESCRIPTION
## What

Add the ability to cancel an in-flight Helm install from the UI path:
- New task statuses `cancelling` (intermediate) and `cancelled` (terminal), plus `RequestHelmOperationCancel` / `HelmOperationTaskIsCancelling`
- The operation recorder polls the task status every second and exposes a `Cancelled()` channel
- The installer watches that channel and aborts the Helm run via `cancelInstall()`; `context.Canceled` is recognized as a user cancellation ("ABORTED: install cancelled by user") instead of an install failure
- New `POST /api/cancel-helm-operation` endpoint (admin + owner checked)
- `Finish` now finalizes tasks in the `cancelling` state

## Why

A failed install (e.g. a pod that can never become ready, or a stuck PVC) leaves the Helm release in `pending-install` and holds the release lock; the only escape was waiting for the 20-minute Helm timeout. The SSE stream is intentionally disconnected-protected (`WithoutCancel`), so closing the browser does not abort the install — but there was no explicit cancel path at all. Cancel requests are stored in persisted task state, independent of any HTTP connection, which keeps the disconnect protection while adding an explicit user cancel.

## Scope

- `object/helm_operation.go` — cancel states, request/query functions, Finish accepts `cancelling`
- `object/helm_operation_recorder.go` — cancel poll goroutine + `Cancelled()`; serialized queue close vs in-flight log sends
- `store/helm.go` — lifecycle interface, cancel watcher, `context.Canceled` branch; tolerated late sends to the closed stream channel
- `controllers/helm.go`, `routers/router.go` — cancel endpoint + route

## Verification

On a live cluster: started an install that could never become ready (bad image tag → `ImagePullBackOff`), called the cancel API, and confirmed the task finished with "install cancelled by user", the release lock was released (`active_key` cleared), and the backend stayed healthy. Two send-on-closed-channel races surfaced during verification and were fixed (serialized recorder close; recover in the stream send).