### PR TITLE
feat: add cancel install button to the install modal

### DIFF
--- a/web/src/HelmInstallModal.js
+++ b/web/src/HelmInstallModal.js
@@ -277,6 +277,27 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
     onClose();
   };
 
+  const [cancelling, setCancelling] = useState(false);
+
+  const handleCancelInstall = () => {
+    const taskId = taskIdRef.current;
+    if (!taskId || cancelling) {return;}
+    setCancelling(true);
+    HelmBackend.cancelHelmOperation(taskId)
+      .then(res => {
+        if (res.status !== "ok") {
+          setError(res.msg || t("helm:Cancel install failed"));
+          setCancelling(false);
+          return;
+        }
+        monitorTask(taskId, taskStorageKeyRef.current, taskIdentityRef.current);
+      })
+      .catch(e => {
+        setError(e.message);
+        setCancelling(false);
+      });
+  };
+
   const handleOk = () => {
     if (done) {
       onInstalled?.();
@@ -436,6 +457,11 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
           {!done && !pollingPaused && (
             <Button type="primary" loading={installing} onClick={handleOk}>
               {t("helm:Install")}
+            </Button>
+          )}
+          {installing && hasActiveTask && (
+            <Button danger loading={cancelling} onClick={handleCancelInstall}>
+              {t("helm:Cancel install")}
             </Button>
           )}
           {pollingPaused && (

--- a/web/src/HelmInstallModal.js
+++ b/web/src/HelmInstallModal.js
@@ -142,6 +142,14 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
             forgetTask(storageKey);
             return;
           }
+          if (task.status === "cancelled") {
+            setInstalling(false);
+            setPollingPaused(false);
+            submittingRef.current = false;
+            forgetTask(storageKey);
+            setDone(true);
+            return;
+          }
           setInstalling(true);
           pollTimerRef.current = setTimeout(poll, 2000);
         })
@@ -282,20 +290,29 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
   const handleCancelInstall = () => {
     const taskId = taskIdRef.current;
     if (!taskId || cancelling) {return;}
-    setCancelling(true);
-    HelmBackend.cancelHelmOperation(taskId)
-      .then(res => {
-        if (res.status !== "ok") {
-          setError(res.msg || t("helm:Cancel install failed"));
-          setCancelling(false);
-          return;
-        }
-        monitorTask(taskId, taskStorageKeyRef.current, taskIdentityRef.current);
-      })
-      .catch(e => {
-        setError(e.message);
-        setCancelling(false);
-      });
+    Modal.confirm({
+      title: t("helm:Cancel this install?"),
+      content: t("helm:Cancel leaves installed resources behind"),
+      okText: t("helm:Cancel install"),
+      okButtonProps: {danger: true},
+      cancelText: t("general:Cancel"),
+      onOk: () => {
+        setCancelling(true);
+        HelmBackend.cancelHelmOperation(taskId)
+          .then(res => {
+            if (res.status !== "ok") {
+              setError(res.msg || t("helm:Cancel install failed"));
+              setCancelling(false);
+              return;
+            }
+            monitorTask(taskId, taskStorageKeyRef.current, taskIdentityRef.current);
+          })
+          .catch(e => {
+            setError(e.message);
+            setCancelling(false);
+          });
+      },
+    });
   };
 
   const handleOk = () => {

--- a/web/src/backend/HelmBackend.js
+++ b/web/src/backend/HelmBackend.js
@@ -50,6 +50,12 @@ export function getHelmOperationTask(id) {
   }).then(r => r.json());
 }
 
+export function cancelHelmOperation(taskId) {
+  return fetch(`${Setting.ServerUrl}/api/cancel-helm-operation`, {
+    method: "POST", credentials: "include", headers: jsonHeaders(), body: JSON.stringify({taskId}),
+  }).then(r => r.json());
+}
+
 export function installHelmChart(payload) {
   return fetch(`${Setting.ServerUrl}/api/install-helm-chart`, {
     method: "POST", credentials: "include", headers: jsonHeaders(), body: JSON.stringify(payload),

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -119,7 +119,9 @@
     "Kubernetes API unavailable": "The Kubernetes API is unavailable. Check the control plane and network connection.",
     "Helm dry run failed": "The Helm preflight check failed. Check the chart templates, values, and error details.",
     "Missing resource": "Missing resource",
-    "Compatibility details": "Details"
+    "Compatibility details": "Details",
+    "Cancel install": "Cancel install",
+    "Cancel install failed": "Cancel install failed"
   },
   "monitor": {
     "Abnormal Pods": "Abnormal Pods",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -121,7 +121,9 @@
     "Missing resource": "Missing resource",
     "Compatibility details": "Details",
     "Cancel install": "Cancel install",
-    "Cancel install failed": "Cancel install failed"
+    "Cancel install failed": "Cancel install failed",
+    "Cancel this install?": "Cancel this install?",
+    "Cancel leaves installed resources behind": "Cancelled operations leave already-created resources behind; uninstall them from the Helm Releases page."
   },
   "monitor": {
     "Abnormal Pods": "Abnormal Pods",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -119,7 +119,9 @@
     "Kubernetes API unavailable": "Kubernetes API 当前不可用，请检查控制面状态和网络连接。",
     "Helm dry run failed": "Helm 预检失败，请检查 Chart 模板、values 和错误详情。",
     "Missing resource": "缺少资源",
-    "Compatibility details": "详细信息"
+    "Compatibility details": "详细信息",
+    "Cancel install": "取消安装",
+    "Cancel install failed": "取消安装失败"
   },
   "monitor": {
     "Abnormal Pods": "异常 Pod",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -121,7 +121,9 @@
     "Missing resource": "缺少资源",
     "Compatibility details": "详细信息",
     "Cancel install": "取消安装",
-    "Cancel install failed": "取消安装失败"
+    "Cancel install failed": "取消安装失败",
+    "Cancel this install?": "取消本次安装？",
+    "Cancel leaves installed resources behind": "取消后已创建的资源会保留，请到 Helm Releases 页卸载。"
   },
   "monitor": {
     "Abnormal Pods": "异常 Pod",


### PR DESCRIPTION
## What

Show a danger "Cancel install" button in the Helm install modal while an install is in flight, wired to the new `POST /api/cancel-helm-operation` endpoint (added in #128). After a successful cancel request the UI resumes task polling so the modal reflects the `cancelled` terminal state. Adds `cancelHelmOperation` to HelmBackend and en/zh i18n strings.

## Why

#128 added the backend cancel capability (persisted `cancelling` state, recorder polling, installer abort) but no UI entry point. Users hitting a stuck install (e.g. a pod that can never become ready) previously had no way to stop it from the modal — only the 20-minute Helm timeout or background-close semantics. This button exposes the cancel path.

## Scope

- `web/src/backend/HelmBackend.js` — `cancelHelmOperation(taskId)`
- `web/src/HelmInstallModal.js` — cancel button (shown while `installing && hasActiveTask`), cancel handler with in-flight guard, resumes task polling after cancel
- `web/src/locales/en|zh/data.json` — "Cancel install" strings

## Verification

Syntax and eslint pass. Functional check requires the backend from #128 and a browser: start an install that cannot become ready, click Cancel install, confirm the task reaches `cancelled` and the modal reflects it.