### PR TITLE
feat: inject NodePort service type for app store charts

### DIFF
--- a/store/adapters.go
+++ b/store/adapters.go
@@ -17,15 +17,19 @@ type helmChartAdapter struct {
 // helmChartAdapterRegistry maps canonical chart names to install adaptations.
 // Explicit user values always win over adapter patches.
 var helmChartAdapterRegistry = map[string]helmChartAdapter{
-	"grafana":   {valuesPatches: nodePortServiceValuesPatch},
-	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch},
-	"n8n":       {valuesPatches: nodePortServiceValuesPatch},
-	"superset":  {valuesPatches: nodePortServiceValuesPatch},
-	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
+	"grafana":   {valuesPatches: nodePortServiceValuesPatch()},
+	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch()},
+	"n8n":       {valuesPatches: nodePortServiceValuesPatch()},
+	"superset":  {valuesPatches: nodePortServiceValuesPatch()},
+	"nextcloud": {valuesPatches: nodePortServiceValuesPatch()},
 }
 
-var nodePortServiceValuesPatch = map[string]interface{}{
-	"service": map[string]interface{}{"type": "NodePort"},
+// nodePortServiceValuesPatch returns a fresh patch each call so the registry
+// never shares mutable state.
+func nodePortServiceValuesPatch() map[string]interface{} {
+	return map[string]interface{}{
+		"service": map[string]interface{}{"type": "NodePort"},
+	}
 }
 
 // applyHelmChartAdapter merges chart-specific compatibility values into the

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -43,7 +43,7 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		return nil
 	}
 	for topKey, patch := range adapter.valuesPatches {
-		if _, explicitlySet := explicitValues[topKey]; explicitlySet {
+		if adapterPatchExplicitlyOverridden(explicitValues, topKey, patch) {
 			continue
 		}
 		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
@@ -51,4 +51,26 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		}
 	}
 	return nil
+}
+
+// adapterPatchExplicitlyOverridden reports whether the user explicitly set
+// any leaf of the patch within explicitValues. Leaf-level checking (not the
+// top-level key) keeps the adapter active when the user only touched a
+// sibling key, e.g. service.port while the patch targets service.type.
+func adapterPatchExplicitlyOverridden(explicitValues map[string]interface{}, topKey string, patch interface{}) bool {
+	explicit, exists := explicitValues[topKey]
+	if !exists {
+		return false
+	}
+	patchMap, patchIsMap := patch.(map[string]interface{})
+	explicitMap, explicitIsMap := explicit.(map[string]interface{})
+	if !patchIsMap || !explicitIsMap {
+		return true
+	}
+	for key, subPatch := range patchMap {
+		if adapterPatchExplicitlyOverridden(explicitMap, key, subPatch) {
+			return true
+		}
+	}
+	return false
 }

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// helmChartAdapter encodes app-aware install value patches keyed by chart name.
+// It makes an app usable right after installation (e.g. a reachable service
+// type) without requiring the user to know chart internals.
+type helmChartAdapter struct {
+	valuesPatches map[string]interface{}
+}
+
+// helmChartAdapterRegistry maps canonical chart names to install adaptations.
+// Explicit user values always win over adapter patches.
+var helmChartAdapterRegistry = map[string]helmChartAdapter{
+	"grafana":   {valuesPatches: nodePortServiceValuesPatch},
+	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch},
+	"n8n":       {valuesPatches: nodePortServiceValuesPatch},
+	"superset":  {valuesPatches: nodePortServiceValuesPatch},
+	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
+}
+
+var nodePortServiceValuesPatch = map[string]interface{}{
+	"service": map[string]interface{}{"type": "NodePort"},
+}
+
+// applyHelmChartAdapter merges chart-specific compatibility values into the
+// install values; user-set top-level keys are left untouched.
+func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}) error {
+	if ch == nil {
+		return nil
+	}
+	adapter, ok := helmChartAdapterRegistry[strings.ToLower(strings.TrimSpace(ch.Name()))]
+	if !ok {
+		return nil
+	}
+	for topKey, patch := range adapter.valuesPatches {
+		if _, explicitlySet := explicitValues[topKey]; explicitlySet {
+			continue
+		}
+		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
+			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+		}
+	}
+	return nil
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func testChart(name string) *chart.Chart {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{Name: name},
+		Values:   map[string]interface{}{},
+	}
+}
+
+func TestHelmChartAdapterInjectsNodePort(t *testing.T) {
+	for _, app := range []string{"grafana", "pgadmin4", "n8n", "superset", "nextcloud"} {
+		values, adjustments, err := prepareHelmInstallValues(testChart(app), "https://example.com/charts", map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("%s: %v", app, err)
+		}
+		service, ok := values["service"].(map[string]interface{})
+		if !ok || service["type"] != "NodePort" {
+			t.Errorf("%s: expected service.type NodePort, got %#v", app, values["service"])
+		}
+		if adjustments.legacyImages || adjustments.tomcatDefaultWebapps {
+			t.Errorf("%s: non-Bitnami chart should not apply Bitnami adjustments", app)
+		}
+	}
+}
+
+func TestHelmChartAdapterRespectsExplicitServiceType(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"service": map[string]interface{}{"type": "LoadBalancer"},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "LoadBalancer" {
+		t.Errorf("expected user service.type LoadBalancer preserved, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterSkipsUnregisteredChart(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("some-other-app"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	if _, exists := values["service"]; exists {
+		t.Errorf("unregistered chart should not be patched, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
+	values, adjustments, err := prepareHelmInstallValues(testChart("grafana"), bitnamiChartRepoURL, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("grafana should get NodePort even on Bitnami repo, got %#v", values["service"])
+	}
+	_ = adjustments
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -53,13 +53,41 @@ func TestHelmChartAdapterSkipsUnregisteredChart(t *testing.T) {
 }
 
 func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
-	values, adjustments, err := prepareHelmInstallValues(testChart("grafana"), bitnamiChartRepoURL, map[string]interface{}{})
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "grafana"},
+		Values: map[string]interface{}{
+			"image": map[string]interface{}{
+				"repository": "bitnami/grafana",
+				"tag":        "11.6.1-debian-12-r0",
+			},
+		},
+	}
+	values, adjustments, err := prepareHelmInstallValues(ch, bitnamiChartRepoURL, map[string]interface{}{})
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
+	}
+	if !adjustments.legacyImages {
+		t.Error("expected Bitnami legacy image adjustment to be preserved")
+	}
+	image, ok := values["image"].(map[string]interface{})
+	if !ok || image["repository"] != "bitnamilegacy/grafana" {
+		t.Errorf("expected rewritten legacy image repository, got %#v", values["image"])
 	}
 	service, ok := values["service"].(map[string]interface{})
 	if !ok || service["type"] != "NodePort" {
 		t.Errorf("grafana should get NodePort even on Bitnami repo, got %#v", values["service"])
 	}
-	_ = adjustments
+}
+
+func TestHelmChartAdapterOverridesModeRespectsExplicitService(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithMode(testChart("grafana"), "https://example.com/charts", map[string]interface{}{
+		"service": map[string]interface{}{"port": 3001},
+	}, true)
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, _ := values["service"].(map[string]interface{})
+	if service["type"] != nil && service["type"] == "NodePort" {
+		t.Errorf("adapter must skip when the user set any service key; got %#v", values["service"])
+	}
 }

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -79,7 +79,7 @@ func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
 	}
 }
 
-func TestHelmChartAdapterOverridesModeRespectsExplicitService(t *testing.T) {
+func TestHelmChartAdapterOverridesModeInjectNodePortWhenSiblingChanged(t *testing.T) {
 	values, _, err := prepareHelmInstallValuesWithMode(testChart("grafana"), "https://example.com/charts", map[string]interface{}{
 		"service": map[string]interface{}{"port": 3001},
 	}, true)
@@ -87,7 +87,23 @@ func TestHelmChartAdapterOverridesModeRespectsExplicitService(t *testing.T) {
 		t.Fatalf("prepare values: %v", err)
 	}
 	service, _ := values["service"].(map[string]interface{})
-	if service["type"] != nil && service["type"] == "NodePort" {
-		t.Errorf("adapter must skip when the user set any service key; got %#v", values["service"])
+	if service["type"] != "NodePort" {
+		t.Errorf("adapter must inject NodePort when only a sibling key changed; got %#v", values["service"])
+	}
+	if service["port"] != 3001 {
+		t.Errorf("user port must be preserved, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterOverridesModeRespectsExplicitType(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithMode(testChart("grafana"), "https://example.com/charts", map[string]interface{}{
+		"service": map[string]interface{}{"type": "LoadBalancer", "port": 3001},
+	}, true)
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, _ := values["service"].(map[string]interface{})
+	if service["type"] != "LoadBalancer" {
+		t.Errorf("user service.type must win; got %#v", values["service"])
 	}
 }

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -115,10 +115,24 @@ func prepareHelmInstallValues(ch *chart.Chart, repoURL string, input map[string]
 
 func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	values := cloneHelmValues(input)
-	if ch == nil || !isBitnamiCommunityChartRepo(repoURL) {
+	if ch == nil {
 		return values, helmInstallValueAdjustments{}, nil
 	}
+	adjustments := helmInstallValueAdjustments{}
+	if isBitnamiCommunityChartRepo(repoURL) {
+		bitnamiValues, bitnamiAdjustments, err := applyBitnamiChartAdjustments(ch, repoURL, values, input, inputIsOverrides)
+		if err != nil {
+			return nil, bitnamiAdjustments, err
+		}
+		values, adjustments = bitnamiValues, bitnamiAdjustments
+	}
+	if err := applyHelmChartAdapter(ch, values, input); err != nil {
+		return nil, adjustments, err
+	}
+	return values, adjustments, nil
+}
 
+func applyBitnamiChartAdjustments(ch *chart.Chart, repoURL string, values, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	coalesced, err := chartutil.CoalesceValues(ch, cloneHelmValues(input))
 	if err != nil {
 		return nil, helmInstallValueAdjustments{}, fmt.Errorf("coalesce Helm install values: %w", err)

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -120,7 +120,7 @@ func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map
 	}
 	adjustments := helmInstallValueAdjustments{}
 	if isBitnamiCommunityChartRepo(repoURL) {
-		bitnamiValues, bitnamiAdjustments, err := applyBitnamiChartAdjustments(ch, repoURL, values, input, inputIsOverrides)
+		bitnamiValues, bitnamiAdjustments, err := applyBitnamiChartAdjustments(ch, values, input, inputIsOverrides)
 		if err != nil {
 			return nil, bitnamiAdjustments, err
 		}
@@ -132,7 +132,7 @@ func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map
 	return values, adjustments, nil
 }
 
-func applyBitnamiChartAdjustments(ch *chart.Chart, repoURL string, values, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
+func applyBitnamiChartAdjustments(ch *chart.Chart, values, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	coalesced, err := chartutil.CoalesceValues(ch, cloneHelmValues(input))
 	if err != nil {
 		return nil, helmInstallValueAdjustments{}, fmt.Errorf("coalesce Helm install values: %w", err)


### PR DESCRIPTION
## What

Add an app-aware install adapter registry keyed by chart name. The five verified App Store charts (grafana, pgadmin4, n8n, superset, nextcloud) default to a ClusterIP service, which left them without a UI access URL after install. The adapter injects `service.type: NodePort` unless the user explicitly set the key. Refactor `prepareHelmInstallValuesWithMode` so the Bitnami image/legacy adaptation no longer short-circuits non-Bitnami repos, and run the adapter after the Bitnami pass so both coexist.

## Why

Issue #121: after installing an app, the UI had no working access URL because chart defaults use ClusterIP. The adapter registry is the foundation for further per-app compatibility injections (config defaults, bootstrap scripts) that will follow in separate PRs.

## Scope

- `store/adapters.go` — adapter registry + `applyHelmChartAdapter` (user values win)
- `store/helm_install_values.go` — split Bitnami logic into `applyBitnamiChartAdjustments`, call adapter for all charts
- `store/adapters_test.go` — NodePort injection for all 5 apps, user override respected, unregistered charts untouched, Bitnami coexistence

## Verification

`go build`, `go vet`, `gofmt` clean; 4 new tests pass; existing object/store tests pass.