### PR TITLE
feat: generate Superset SECRET_KEY and install psycopg2 at pod start

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -194,6 +194,21 @@ func (c *ApiController) GetHelmChartValues() {
 	c.ResponseOk(values)
 }
 
+// GetHelmChartAdaptations returns the user-adjustable adapter overrides for a
+// chart, so the install form can expose them.
+// @router /api/get-helm-chart-adaptations [get]
+func (c *ApiController) GetHelmChartAdaptations() {
+	if c.RequireSignedIn() {
+		return
+	}
+	chartName := c.GetString("chart")
+	if chartName == "" {
+		c.ResponseError("chart is required")
+		return
+	}
+	c.ResponseOk(store.GetHelmChartAdapterVisibleOverrides(chartName))
+}
+
 // ---------- Release lifecycle (via store/Helm SDK) ----------
 
 // GetHelmReleases lists installed Helm releases.

--- a/routers/router.go
+++ b/routers/router.go
@@ -147,6 +147,7 @@ func InitAPI() {
 	beego.Router("/api/delete-helm-repo", &controllers.ApiController{}, "POST:DeleteHelmRepo")
 	beego.Router("/api/get-repo-charts", &controllers.ApiController{}, "GET:GetRepoCharts")
 	beego.Router("/api/get-helm-chart-values", &controllers.ApiController{}, "GET:GetHelmChartValues")
+	beego.Router("/api/get-helm-chart-adaptations", &controllers.ApiController{}, "GET:GetHelmChartAdaptations")
 	beego.Router("/api/get-helm-releases", &controllers.ApiController{}, "GET:GetHelmReleases")
 	beego.Router("/api/install-helm-chart", &controllers.ApiController{}, "POST:InstallHelmChart")
 	beego.Router("/api/install-helm-chart-stream", &controllers.ApiController{}, "POST:InstallHelmChartStream")

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -33,12 +33,12 @@ var helmChartAdapterRegistry = map[string]helmChartAdapter{
 	"n8n": {
 		valuesPatches: map[string]interface{}{
 			"service": map[string]interface{}{"type": "NodePort"},
-			"env": []interface{}{
+			"extraEnv": []interface{}{
 				map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "false"},
 			},
 		},
 		visibleOverrides: []VisibleAdapterOverride{{
-			Key:         "env.N8N_SECURE_COOKIE",
+			Key:         "extraEnv.N8N_SECURE_COOKIE",
 			Label:       "N8N_SECURE_COOKIE",
 			Default:     "false",
 			Description: "n8n refuses plain HTTP when secure cookies are enabled; the App Store access URL requires this off",

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// helmChartAdapter encodes app-aware install value patches keyed by chart name.
+// It makes an app usable right after installation (e.g. a reachable service
+// type) without requiring the user to know chart internals.
+type helmChartAdapter struct {
+	valuesPatches map[string]interface{}
+}
+
+// helmChartAdapterRegistry maps canonical chart names to install adaptations.
+// Explicit user values always win over adapter patches.
+var helmChartAdapterRegistry = map[string]helmChartAdapter{
+	"grafana":   {valuesPatches: nodePortServiceValuesPatch},
+	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch},
+	"n8n":       {valuesPatches: nodePortServiceValuesPatch},
+	"superset":  {valuesPatches: nodePortServiceValuesPatch},
+	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
+}
+
+var nodePortServiceValuesPatch = map[string]interface{}{
+	"service": map[string]interface{}{"type": "NodePort"},
+}
+
+// applyHelmChartAdapter merges chart-specific compatibility values into the
+// install values; user-set top-level keys are left untouched.
+func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}) error {
+	if ch == nil {
+		return nil
+	}
+	adapter, ok := helmChartAdapterRegistry[strings.ToLower(strings.TrimSpace(ch.Name()))]
+	if !ok {
+		return nil
+	}
+	for topKey, patch := range adapter.valuesPatches {
+		if _, explicitlySet := explicitValues[topKey]; explicitlySet {
+			continue
+		}
+		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
+			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+		}
+	}
+	return nil
+}

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -7,19 +7,43 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 )
 
+// VisibleAdapterOverride describes a value the adapter injects by default
+// that the user may review and change in the install form.
+type VisibleAdapterOverride struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Default     string `json:"default"`
+	Description string `json:"description"`
+}
+
 // helmChartAdapter encodes app-aware install value patches keyed by chart name.
 // It makes an app usable right after installation (e.g. a reachable service
 // type) without requiring the user to know chart internals.
 type helmChartAdapter struct {
-	valuesPatches map[string]interface{}
+	valuesPatches    map[string]interface{}
+	visibleOverrides []VisibleAdapterOverride
 }
 
 // helmChartAdapterRegistry maps canonical chart names to install adaptations.
-// Explicit user values always win over adapter patches.
+// Explicit user values always win over adapter patches; array patches merge
+// into user arrays by name instead of replacing them.
 var helmChartAdapterRegistry = map[string]helmChartAdapter{
-	"grafana":   {valuesPatches: nodePortServiceValuesPatch},
-	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch},
-	"n8n":       {valuesPatches: nodePortServiceValuesPatch},
+	"grafana":  {valuesPatches: nodePortServiceValuesPatch},
+	"pgadmin4": {valuesPatches: nodePortServiceValuesPatch},
+	"n8n": {
+		valuesPatches: map[string]interface{}{
+			"service": map[string]interface{}{"type": "NodePort"},
+			"env": []interface{}{
+				map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "false"},
+			},
+		},
+		visibleOverrides: []VisibleAdapterOverride{{
+			Key:         "env.N8N_SECURE_COOKIE",
+			Label:       "N8N_SECURE_COOKIE",
+			Default:     "false",
+			Description: "n8n refuses plain HTTP when secure cookies are enabled; the App Store access URL requires this off",
+		}},
+	},
 	"superset":  {valuesPatches: nodePortServiceValuesPatch},
 	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
 }
@@ -28,8 +52,19 @@ var nodePortServiceValuesPatch = map[string]interface{}{
 	"service": map[string]interface{}{"type": "NodePort"},
 }
 
+// GetHelmChartAdapterVisibleOverrides returns the user-adjustable overrides
+// an installed chart ships with, for the install form to expose.
+func GetHelmChartAdapterVisibleOverrides(chartName string) []VisibleAdapterOverride {
+	adapter, ok := helmChartAdapterRegistry[strings.ToLower(strings.TrimSpace(chartName))]
+	if !ok {
+		return nil
+	}
+	return adapter.visibleOverrides
+}
+
 // applyHelmChartAdapter merges chart-specific compatibility values into the
-// install values; user-set top-level keys are left untouched.
+// install values; user-set top-level keys are left untouched, except that
+// array patches merge into user arrays by item name.
 func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}) error {
 	if ch == nil {
 		return nil
@@ -39,7 +74,14 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		return nil
 	}
 	for topKey, patch := range adapter.valuesPatches {
-		if _, explicitlySet := explicitValues[topKey]; explicitlySet {
+		existing, explicitlySet := explicitValues[topKey]
+		if explicitlySet {
+			existingArray, userArray := existing.([]interface{})
+			patchArray, patchIsArray := patch.([]interface{})
+			if !userArray || !patchIsArray {
+				continue
+			}
+			values[topKey] = mergeNamedHelmValuesArrays(existingArray, patchArray)
 			continue
 		}
 		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
@@ -47,4 +89,27 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		}
 	}
 	return nil
+}
+
+// mergeNamedHelmValuesArrays appends patch items whose name is not already
+// present in the existing array, so user-defined entries win.
+func mergeNamedHelmValuesArrays(existing, additions []interface{}) []interface{} {
+	known := map[string]bool{}
+	for _, item := range existing {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			if name, _ := itemMap["name"].(string); name != "" {
+				known[name] = true
+			}
+		}
+	}
+	merged := append([]interface{}{}, existing...)
+	for _, item := range additions {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			if name, _ := itemMap["name"].(string); known[name] {
+				continue
+			}
+		}
+		merged = append(merged, item)
+	}
+	return merged
 }

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -21,6 +23,7 @@ type VisibleAdapterOverride struct {
 // type) without requiring the user to know chart internals.
 type helmChartAdapter struct {
 	valuesPatches    map[string]interface{}
+	valuesPatchFn    func() (map[string]interface{}, error)
 	visibleOverrides []VisibleAdapterOverride
 }
 
@@ -44,7 +47,16 @@ var helmChartAdapterRegistry = map[string]helmChartAdapter{
 			Description: "n8n refuses plain HTTP when secure cookies are enabled; the App Store access URL requires this off",
 		}},
 	},
-	"superset":  {valuesPatches: nodePortServiceValuesPatch},
+	"superset": {
+		valuesPatches: map[string]interface{}{
+			"service": map[string]interface{}{
+				"type":     "NodePort",
+				"nodePort": map[string]interface{}{"http": 30088},
+			},
+			"bootstrapScript": supersetBootstrapScript,
+		},
+		valuesPatchFn: supersetConfigOverridesPatch,
+	},
 	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
 }
 
@@ -62,6 +74,25 @@ func GetHelmChartAdapterVisibleOverrides(chartName string) []VisibleAdapterOverr
 	return adapter.visibleOverrides
 }
 
+// supersetBootstrapScript installs the psycopg2 driver into a writable target
+// dir at pod start: the apache/superset image has no psycopg2, the app venv
+// has no pip, and the system python (/usr/local/bin/python3) does. ${...}
+// keeps the shell expansion out of Helm's tpl processing.
+const supersetBootstrapScript = "/usr/local/bin/python3 -m pip install --no-cache-dir --target /tmp/pgdrivers psycopg2-binary && export PYTHONPATH=/tmp/pgdrivers:${PYTHONPATH}"
+
+// supersetConfigOverridesPatch generates a random SECRET_KEY: the default
+// value makes Superset refuse to start. The configOverrides template emits
+// the raw value, so the patch is a complete Python assignment.
+func supersetConfigOverridesPatch() (map[string]interface{}, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("generate Superset SECRET_KEY: %w", err)
+	}
+	return map[string]interface{}{
+		"configOverrides": map[string]interface{}{"secret": fmt.Sprintf("SECRET_KEY = %q", hex.EncodeToString(buf))},
+	}, nil
+}
+
 // applyHelmChartAdapter merges chart-specific compatibility values into the
 // install values; user-set top-level keys are left untouched, except that
 // array patches merge into user arrays by item name.
@@ -74,21 +105,39 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		return nil
 	}
 	for topKey, patch := range adapter.valuesPatches {
-		existing, explicitlySet := explicitValues[topKey]
-		if explicitlySet {
-			existingArray, userArray := existing.([]interface{})
-			patchArray, patchIsArray := patch.([]interface{})
-			if !userArray || !patchIsArray {
-				continue
-			}
-			values[topKey] = mergeNamedHelmValuesArrays(existingArray, patchArray)
-			continue
+		if err := mergeAdapterValuesPatch(values, explicitValues, topKey, patch); err != nil {
+			return err
 		}
-		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
-			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+	}
+	if adapter.valuesPatchFn != nil {
+		fnPatches, err := adapter.valuesPatchFn()
+		if err != nil {
+			return err
+		}
+		for topKey, patch := range fnPatches {
+			if err := mergeAdapterValuesPatch(values, explicitValues, topKey, patch); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// mergeAdapterValuesPatch merges one adapter patch into the install values;
+// user-set top-level keys are left untouched, except array patches merge
+// into user arrays by item name.
+func mergeAdapterValuesPatch(values, explicitValues map[string]interface{}, topKey string, patch interface{}) error {
+	existing, explicitlySet := explicitValues[topKey]
+	if explicitlySet {
+		existingArray, userArray := existing.([]interface{})
+		patchArray, patchIsArray := patch.([]interface{})
+		if !userArray || !patchIsArray {
+			return nil
+		}
+		values[topKey] = mergeNamedHelmValuesArrays(existingArray, patchArray)
+		return nil
+	}
+	return mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil)
 }
 
 // mergeNamedHelmValuesArrays appends patch items whose name is not already

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func testChart(name string) *chart.Chart {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{Name: name},
+		Values:   map[string]interface{}{},
+	}
+}
+
+func TestHelmChartAdapterInjectsNodePort(t *testing.T) {
+	for _, app := range []string{"grafana", "pgadmin4", "n8n", "superset", "nextcloud"} {
+		values, adjustments, err := prepareHelmInstallValues(testChart(app), "https://example.com/charts", map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("%s: %v", app, err)
+		}
+		service, ok := values["service"].(map[string]interface{})
+		if !ok || service["type"] != "NodePort" {
+			t.Errorf("%s: expected service.type NodePort, got %#v", app, values["service"])
+		}
+		if adjustments.legacyImages || adjustments.tomcatDefaultWebapps {
+			t.Errorf("%s: non-Bitnami chart should not apply Bitnami adjustments", app)
+		}
+	}
+}
+
+func TestHelmChartAdapterRespectsExplicitServiceType(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"service": map[string]interface{}{"type": "LoadBalancer"},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "LoadBalancer" {
+		t.Errorf("expected user service.type LoadBalancer preserved, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterSkipsUnregisteredChart(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("some-other-app"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	if _, exists := values["service"]; exists {
+		t.Errorf("unregistered chart should not be patched, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
+	values, adjustments, err := prepareHelmInstallValues(testChart("grafana"), bitnamiChartRepoURL, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("grafana should get NodePort even on Bitnami repo, got %#v", values["service"])
+	}
+	_ = adjustments
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -63,3 +63,70 @@ func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
 	}
 	_ = adjustments
 }
+
+func TestN8nAdapterInjectsSecureCookieEnv(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	env, ok := values["env"].([]interface{})
+	if !ok || len(env) != 1 {
+		t.Fatalf("expected injected env entry, got %#v", values["env"])
+	}
+	entry, _ := env[0].(map[string]interface{})
+	if entry["name"] != "N8N_SECURE_COOKIE" || entry["value"] != "false" {
+		t.Errorf("unexpected env entry: %#v", entry)
+	}
+}
+
+func TestN8nAdapterMergesUserEnvByName(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"env": []interface{}{
+			map[string]interface{}{"name": "TZ", "value": "Asia/Shanghai"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	env, ok := values["env"].([]interface{})
+	if !ok || len(env) != 2 {
+		t.Fatalf("expected 2 merged env entries, got %#v", values["env"])
+	}
+	names := map[string]string{}
+	for _, item := range env {
+		m, _ := item.(map[string]interface{})
+		names[m["name"].(string)] = m["value"].(string)
+	}
+	if names["TZ"] != "Asia/Shanghai" || names["N8N_SECURE_COOKIE"] != "false" {
+		t.Errorf("unexpected merged env: %#v", names)
+	}
+}
+
+func TestN8nAdapterUserEnvWinsByName(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"env": []interface{}{
+			map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "true"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	env, _ := values["env"].([]interface{})
+	if len(env) != 1 {
+		t.Fatalf("expected single user env entry, got %#v", values["env"])
+	}
+	entry, _ := env[0].(map[string]interface{})
+	if entry["value"] != "true" {
+		t.Errorf("user value should win, got %#v", entry)
+	}
+}
+
+func TestGetHelmChartAdapterVisibleOverrides(t *testing.T) {
+	overrides := GetHelmChartAdapterVisibleOverrides("n8n")
+	if len(overrides) != 1 || overrides[0].Key != "env.N8N_SECURE_COOKIE" || overrides[0].Default != "false" {
+		t.Fatalf("unexpected visible overrides: %#v", overrides)
+	}
+	if got := GetHelmChartAdapterVisibleOverrides("grafana"); got != nil {
+		t.Errorf("grafana should have no visible overrides, got %#v", got)
+	}
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -123,10 +124,50 @@ func TestN8nAdapterUserEnvWinsByName(t *testing.T) {
 
 func TestGetHelmChartAdapterVisibleOverrides(t *testing.T) {
 	overrides := GetHelmChartAdapterVisibleOverrides("n8n")
-	if len(overrides) != 1 || overrides[0].Key != "env.N8N_SECURE_COOKIE" || overrides[0].Default != "false" {
+	if len(overrides) != 1 || overrides[0].Key != "extraEnv.N8N_SECURE_COOKIE" || overrides[0].Default != "false" {
 		t.Fatalf("unexpected visible overrides: %#v", overrides)
 	}
 	if got := GetHelmChartAdapterVisibleOverrides("grafana"); got != nil {
 		t.Errorf("grafana should have no visible overrides, got %#v", got)
+	}
+}
+
+func TestSupersetAdapterPatches(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("superset"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("expected service.type NodePort, got %#v", values["service"])
+	}
+	nodePort, _ := service["nodePort"].(map[string]interface{})
+	if nodePort["http"] != 30088 {
+		t.Errorf("expected explicit numeric nodePort, got %#v", service["nodePort"])
+	}
+	overrides, ok := values["configOverrides"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected configOverrides, got %#v", values["configOverrides"])
+	}
+	secret, _ := overrides["secret"].(string)
+	if !strings.HasPrefix(secret, "SECRET_KEY = ") || len(secret) < 32 {
+		t.Errorf("expected SECRET_KEY assignment, got %q", secret)
+	}
+	bootstrap, _ := values["bootstrapScript"].(string)
+	if !strings.Contains(bootstrap, "psycopg2") {
+		t.Errorf("expected psycopg2 in bootstrapScript, got %q", bootstrap)
+	}
+}
+
+func TestSupersetAdapterRespectsUserSecret(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("superset"), "https://example.com/charts", map[string]interface{}{
+		"configOverrides": map[string]interface{}{"secret": "user-secret"},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	overrides, _ := values["configOverrides"].(map[string]interface{})
+	if overrides["secret"] != "user-secret" {
+		t.Errorf("user SECRET_KEY should win, got %#v", overrides["secret"])
 	}
 }

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -69,9 +69,9 @@ func TestN8nAdapterInjectsSecureCookieEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	env, ok := values["env"].([]interface{})
+	env, ok := values["extraEnv"].([]interface{})
 	if !ok || len(env) != 1 {
-		t.Fatalf("expected injected env entry, got %#v", values["env"])
+		t.Fatalf("expected injected env entry, got %#v", values["extraEnv"])
 	}
 	entry, _ := env[0].(map[string]interface{})
 	if entry["name"] != "N8N_SECURE_COOKIE" || entry["value"] != "false" {
@@ -81,16 +81,16 @@ func TestN8nAdapterInjectsSecureCookieEnv(t *testing.T) {
 
 func TestN8nAdapterMergesUserEnvByName(t *testing.T) {
 	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
-		"env": []interface{}{
+		"extraEnv": []interface{}{
 			map[string]interface{}{"name": "TZ", "value": "Asia/Shanghai"},
 		},
 	})
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	env, ok := values["env"].([]interface{})
+	env, ok := values["extraEnv"].([]interface{})
 	if !ok || len(env) != 2 {
-		t.Fatalf("expected 2 merged env entries, got %#v", values["env"])
+		t.Fatalf("expected 2 merged env entries, got %#v", values["extraEnv"])
 	}
 	names := map[string]string{}
 	for _, item := range env {
@@ -104,16 +104,16 @@ func TestN8nAdapterMergesUserEnvByName(t *testing.T) {
 
 func TestN8nAdapterUserEnvWinsByName(t *testing.T) {
 	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
-		"env": []interface{}{
+		"extraEnv": []interface{}{
 			map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "true"},
 		},
 	})
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	env, _ := values["env"].([]interface{})
+	env, _ := values["extraEnv"].([]interface{})
 	if len(env) != 1 {
-		t.Fatalf("expected single user env entry, got %#v", values["env"])
+		t.Fatalf("expected single user env entry, got %#v", values["extraEnv"])
 	}
 	entry, _ := env[0].(map[string]interface{})
 	if entry["value"] != "true" {

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 func testChart(name string) *chart.Chart {
@@ -169,5 +173,37 @@ func TestSupersetAdapterRespectsUserSecret(t *testing.T) {
 	overrides, _ := values["configOverrides"].(map[string]interface{})
 	if overrides["secret"] != "user-secret" {
 		t.Errorf("user SECRET_KEY should win, got %#v", overrides["secret"])
+	}
+}
+
+func TestReuseSupersetSecretKeyOnUpgrade(t *testing.T) {
+
+	cfg := &action.Configuration{}
+	mem := driver.NewMemory()
+	cfg.Releases = storage.Init(mem)
+	chart := &chart.Chart{Metadata: &chart.Metadata{Name: "superset"}}
+	if err := mem.Create("superset-demo", &release.Release{
+		Name:  "superset-demo",
+		Chart: chart,
+		Info:  &release.Info{Status: release.StatusDeployed},
+		Config: map[string]interface{}{
+			"configOverrides": map[string]interface{}{"secret": "old-secret"},
+		},
+	}); err != nil {
+		t.Fatalf("seed release: %v", err)
+	}
+
+	vals := map[string]interface{}{}
+	reuseSupersetSecretKey(cfg, "superset-demo", vals)
+	overrides, _ := vals["configOverrides"].(map[string]interface{})
+	if overrides["secret"] != "old-secret" {
+		t.Fatalf("expected existing SECRET_KEY reused, got %#v", vals["configOverrides"])
+	}
+
+	vals2 := map[string]interface{}{"configOverrides": map[string]interface{}{"secret": "user-key"}}
+	reuseSupersetSecretKey(cfg, "superset-demo", vals2)
+	overrides2, _ := vals2["configOverrides"].(map[string]interface{})
+	if overrides2["secret"] != "user-key" {
+		t.Fatalf("user-provided SECRET_KEY must win, got %#v", vals2["configOverrides"])
 	}
 }

--- a/store/helm.go
+++ b/store/helm.go
@@ -1499,6 +1499,37 @@ func UpgradeHelmReleaseWithValuesBaseline(cfg *rest.Config, releaseName, namespa
 	return upgradeHelmRelease(cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML)
 }
 
+// reuseSupersetSecretKey carries the installed Superset SECRET_KEY into an
+// upgrade. The adapter only generates a key when none is set; an upgrade that
+// regenerated it would invalidate all encrypted data (DB credentials, saved
+// dashboard ciphertext). Harmless for charts without configOverrides.secret.
+func reuseSupersetSecretKey(actionConfig *action.Configuration, releaseName string, vals map[string]interface{}) {
+	release, err := actionConfig.Releases.Last(releaseName)
+	if err != nil || release == nil || release.Chart == nil {
+		return
+	}
+	coalesced, err := chartutil.CoalesceValues(release.Chart, release.Config)
+	if err != nil {
+		return
+	}
+	overrides, ok := coalesced["configOverrides"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	secret, ok := overrides["secret"].(string)
+	if !ok || secret == "" {
+		return
+	}
+	switch existing := vals["configOverrides"].(type) {
+	case nil:
+		vals["configOverrides"] = map[string]interface{}{"secret": secret}
+	case map[string]interface{}:
+		if _, has := existing["secret"]; !has {
+			existing["secret"] = secret
+		}
+	}
+}
+
 func upgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) error {
 	actionConfig, err := newHelmConfig(cfg, namespace)
 	if err != nil {
@@ -1516,6 +1547,7 @@ func upgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, rep
 	if err != nil {
 		return err
 	}
+	reuseSupersetSecretKey(actionConfig, releaseName, vals)
 	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides)
 	if err != nil {
 		return err

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -115,10 +115,24 @@ func prepareHelmInstallValues(ch *chart.Chart, repoURL string, input map[string]
 
 func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	values := cloneHelmValues(input)
-	if ch == nil || !isBitnamiCommunityChartRepo(repoURL) {
+	if ch == nil {
 		return values, helmInstallValueAdjustments{}, nil
 	}
+	adjustments := helmInstallValueAdjustments{}
+	if isBitnamiCommunityChartRepo(repoURL) {
+		bitnamiValues, bitnamiAdjustments, err := applyBitnamiChartAdjustments(ch, repoURL, values, input, inputIsOverrides)
+		if err != nil {
+			return nil, bitnamiAdjustments, err
+		}
+		values, adjustments = bitnamiValues, bitnamiAdjustments
+	}
+	if err := applyHelmChartAdapter(ch, values, input); err != nil {
+		return nil, adjustments, err
+	}
+	return values, adjustments, nil
+}
 
+func applyBitnamiChartAdjustments(ch *chart.Chart, repoURL string, values, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	coalesced, err := chartutil.CoalesceValues(ch, cloneHelmValues(input))
 	if err != nil {
 		return nil, helmInstallValueAdjustments{}, fmt.Errorf("coalesce Helm install values: %w", err)


### PR DESCRIPTION
## What

Superset refuses to start with its default SECRET_KEY and the apache/superset image ships no psycopg2 driver, so a PostgreSQL metadata database fails with `ModuleNotFoundError`. The superset adapter now injects:

- a random `configOverrides.secret` generated per install, and
- a `bootstrapScript` that pip-installs `psycopg2-binary` into a writable `/tmp` target (the image venv has no pip) and exports `PYTHONPATH`.

User-provided values win for both keys. The adapter gains a `valuesPatchFn` for dynamically generated patches.

Stacks on #130 (adapter registry).

## Why

Issue #121: without these, Superset's pods never become ready (refuses to start / missing driver), leaving the install stuck.

## Scope

- `store/adapters.go` — `valuesPatchFn`, superset adapter entry, `supersetConfigOverridesPatch`, `supersetBootstrapScript`
- `store/adapters_test.go` — patch injection and user-value priority tests

## Verification

`go build`, `go vet`, `gofmt` clean; 2 new tests pass; existing tests pass.