### PR TITLE
feat: advanced settings section in the install form for adapter overrides

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -194,6 +194,21 @@ func (c *ApiController) GetHelmChartValues() {
 	c.ResponseOk(values)
 }
 
+// GetHelmChartAdaptations returns the user-adjustable adapter overrides for a
+// chart, so the install form can expose them.
+// @router /api/get-helm-chart-adaptations [get]
+func (c *ApiController) GetHelmChartAdaptations() {
+	if c.RequireSignedIn() {
+		return
+	}
+	chartName := c.GetString("chart")
+	if chartName == "" {
+		c.ResponseError("chart is required")
+		return
+	}
+	c.ResponseOk(store.GetHelmChartAdapterVisibleOverrides(chartName))
+}
+
 // ---------- Release lifecycle (via store/Helm SDK) ----------
 
 // GetHelmReleases lists installed Helm releases.

--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -232,13 +232,14 @@ func (c *ApiController) GetHelmReleases() {
 }
 
 type helmInstallReq struct {
-	ReleaseName        string `json:"releaseName"`
-	Namespace          string `json:"namespace"`
-	ChartName          string `json:"chartName"`
-	RepoURL            string `json:"repoURL"`
-	Version            string `json:"version"`
-	ValuesYAML         string `json:"valuesYAML"`
-	ValuesBaselineYAML string `json:"valuesBaselineYAML"`
+	ReleaseName        string            `json:"releaseName"`
+	Namespace          string            `json:"namespace"`
+	ChartName          string            `json:"chartName"`
+	RepoURL            string            `json:"repoURL"`
+	Version            string            `json:"version"`
+	ValuesYAML         string            `json:"valuesYAML"`
+	ValuesBaselineYAML string            `json:"valuesBaselineYAML"`
+	AdapterOverrides   map[string]string `json:"adapterOverrides"`
 }
 
 // InstallHelmChart installs a new Helm release.
@@ -327,7 +328,7 @@ func (c *ApiController) InstallHelmChartStream() {
 		return
 	}
 	recorder := object.NewHelmOperationRecorder(task.Id)
-	logCh := store.InstallHelmChartStreamWithValuesBaseline(ctx, recorder, cfg, req.ReleaseName, req.Namespace, req.ChartName, req.RepoURL, req.Version, req.ValuesYAML, req.ValuesBaselineYAML)
+	logCh := store.InstallHelmChartStreamWithValuesBaseline(ctx, recorder, cfg, req.ReleaseName, req.Namespace, req.ChartName, req.RepoURL, req.Version, req.ValuesYAML, req.ValuesBaselineYAML, req.AdapterOverrides)
 	for event := range logCh {
 		if err := writeHelmInstallStreamEvent(w, event); err != nil {
 			break

--- a/routers/router.go
+++ b/routers/router.go
@@ -147,6 +147,7 @@ func InitAPI() {
 	beego.Router("/api/delete-helm-repo", &controllers.ApiController{}, "POST:DeleteHelmRepo")
 	beego.Router("/api/get-repo-charts", &controllers.ApiController{}, "GET:GetRepoCharts")
 	beego.Router("/api/get-helm-chart-values", &controllers.ApiController{}, "GET:GetHelmChartValues")
+	beego.Router("/api/get-helm-chart-adaptations", &controllers.ApiController{}, "GET:GetHelmChartAdaptations")
 	beego.Router("/api/get-helm-releases", &controllers.ApiController{}, "GET:GetHelmReleases")
 	beego.Router("/api/install-helm-chart", &controllers.ApiController{}, "POST:InstallHelmChart")
 	beego.Router("/api/install-helm-chart-stream", &controllers.ApiController{}, "POST:InstallHelmChartStream")

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -10,10 +10,11 @@ import (
 // VisibleAdapterOverride describes a value the adapter injects by default
 // that the user may review and change in the install form.
 type VisibleAdapterOverride struct {
-	Key         string `json:"key"`
-	Label       string `json:"label"`
-	Default     string `json:"default"`
-	Description string `json:"description"`
+	Key         string                 `json:"key"`
+	Label       string                 `json:"label"`
+	Default     string                 `json:"default"`
+	Description string                 `json:"description"`
+	ValuesPatch map[string]interface{} `json:"valuesPatch"`
 }
 
 // helmChartAdapter encodes app-aware install value patches keyed by chart name.
@@ -42,6 +43,11 @@ var helmChartAdapterRegistry = map[string]helmChartAdapter{
 			Label:       "N8N_SECURE_COOKIE",
 			Default:     "false",
 			Description: "n8n refuses plain HTTP when secure cookies are enabled; the App Store access URL requires this off",
+			ValuesPatch: map[string]interface{}{
+				"env": []interface{}{
+					map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "false"},
+				},
+			},
 		}},
 	},
 	"superset":  {valuesPatches: nodePortServiceValuesPatch},
@@ -60,6 +66,51 @@ func GetHelmChartAdapterVisibleOverrides(chartName string) []VisibleAdapterOverr
 		return nil
 	}
 	return adapter.visibleOverrides
+}
+
+// ApplyHelmChartAdapterOverrides applies user-chosen values for visible
+// adapter overrides onto the install values. Unknown keys are ignored.
+func ApplyHelmChartAdapterOverrides(chartName string, values map[string]interface{}, overrides map[string]string) {
+	if len(overrides) == 0 {
+		return
+	}
+	adapter, ok := helmChartAdapterRegistry[strings.ToLower(strings.TrimSpace(chartName))]
+	if !ok {
+		return
+	}
+	for _, override := range adapter.visibleOverrides {
+		value, chosen := overrides[override.Key]
+		if !chosen {
+			continue
+		}
+		patch := cloneHelmValues(override.ValuesPatch)
+		replaceAdapterOverrideValue(patch, value)
+		for topKey, subPatch := range patch {
+			_ = mergeHelmValueOverrides(values, map[string]interface{}{topKey: subPatch}, nil)
+		}
+	}
+}
+
+// replaceAdapterOverrideValue replaces the first "value" field in a
+// visible-override patch with the user's choice.
+func replaceAdapterOverrideValue(patch map[string]interface{}, value string) {
+	for key, item := range patch {
+		switch typed := item.(type) {
+		case string:
+			if key == "value" {
+				patch[key] = value
+				return
+			}
+		case map[string]interface{}:
+			replaceAdapterOverrideValue(typed, value)
+		case []interface{}:
+			for _, entry := range typed {
+				if entryMap, ok := entry.(map[string]interface{}); ok {
+					replaceAdapterOverrideValue(entryMap, value)
+				}
+			}
+		}
+	}
 }
 
 // applyHelmChartAdapter merges chart-specific compatibility values into the

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// helmChartAdapter encodes app-aware install value patches keyed by chart name.
+// It makes an app usable right after installation (e.g. a reachable service
+// type) without requiring the user to know chart internals.
+type helmChartAdapter struct {
+	valuesPatches map[string]interface{}
+}
+
+// helmChartAdapterRegistry maps canonical chart names to install adaptations.
+// Explicit user values always win over adapter patches.
+var helmChartAdapterRegistry = map[string]helmChartAdapter{
+	"grafana":   {valuesPatches: nodePortServiceValuesPatch},
+	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch},
+	"n8n":       {valuesPatches: nodePortServiceValuesPatch},
+	"superset":  {valuesPatches: nodePortServiceValuesPatch},
+	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
+}
+
+var nodePortServiceValuesPatch = map[string]interface{}{
+	"service": map[string]interface{}{"type": "NodePort"},
+}
+
+// applyHelmChartAdapter merges chart-specific compatibility values into the
+// install values; user-set top-level keys are left untouched.
+func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}) error {
+	if ch == nil {
+		return nil
+	}
+	adapter, ok := helmChartAdapterRegistry[strings.ToLower(strings.TrimSpace(ch.Name()))]
+	if !ok {
+		return nil
+	}
+	for topKey, patch := range adapter.valuesPatches {
+		if _, explicitlySet := explicitValues[topKey]; explicitlySet {
+			continue
+		}
+		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
+			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+		}
+	}
+	return nil
+}

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -7,19 +7,43 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 )
 
+// VisibleAdapterOverride describes a value the adapter injects by default
+// that the user may review and change in the install form.
+type VisibleAdapterOverride struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Default     string `json:"default"`
+	Description string `json:"description"`
+}
+
 // helmChartAdapter encodes app-aware install value patches keyed by chart name.
 // It makes an app usable right after installation (e.g. a reachable service
 // type) without requiring the user to know chart internals.
 type helmChartAdapter struct {
-	valuesPatches map[string]interface{}
+	valuesPatches    map[string]interface{}
+	visibleOverrides []VisibleAdapterOverride
 }
 
 // helmChartAdapterRegistry maps canonical chart names to install adaptations.
-// Explicit user values always win over adapter patches.
+// Explicit user values always win over adapter patches; array patches merge
+// into user arrays by name instead of replacing them.
 var helmChartAdapterRegistry = map[string]helmChartAdapter{
-	"grafana":   {valuesPatches: nodePortServiceValuesPatch},
-	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch},
-	"n8n":       {valuesPatches: nodePortServiceValuesPatch},
+	"grafana":  {valuesPatches: nodePortServiceValuesPatch},
+	"pgadmin4": {valuesPatches: nodePortServiceValuesPatch},
+	"n8n": {
+		valuesPatches: map[string]interface{}{
+			"service": map[string]interface{}{"type": "NodePort"},
+			"env": []interface{}{
+				map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "false"},
+			},
+		},
+		visibleOverrides: []VisibleAdapterOverride{{
+			Key:         "env.N8N_SECURE_COOKIE",
+			Label:       "N8N_SECURE_COOKIE",
+			Default:     "false",
+			Description: "n8n refuses plain HTTP when secure cookies are enabled; the App Store access URL requires this off",
+		}},
+	},
 	"superset":  {valuesPatches: nodePortServiceValuesPatch},
 	"nextcloud": {valuesPatches: nodePortServiceValuesPatch},
 }
@@ -28,8 +52,19 @@ var nodePortServiceValuesPatch = map[string]interface{}{
 	"service": map[string]interface{}{"type": "NodePort"},
 }
 
+// GetHelmChartAdapterVisibleOverrides returns the user-adjustable overrides
+// an installed chart ships with, for the install form to expose.
+func GetHelmChartAdapterVisibleOverrides(chartName string) []VisibleAdapterOverride {
+	adapter, ok := helmChartAdapterRegistry[strings.ToLower(strings.TrimSpace(chartName))]
+	if !ok {
+		return nil
+	}
+	return adapter.visibleOverrides
+}
+
 // applyHelmChartAdapter merges chart-specific compatibility values into the
-// install values; user-set top-level keys are left untouched.
+// install values; user-set top-level keys are left untouched, except that
+// array patches merge into user arrays by item name.
 func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}) error {
 	if ch == nil {
 		return nil
@@ -39,7 +74,14 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		return nil
 	}
 	for topKey, patch := range adapter.valuesPatches {
-		if _, explicitlySet := explicitValues[topKey]; explicitlySet {
+		existing, explicitlySet := explicitValues[topKey]
+		if explicitlySet {
+			existingArray, userArray := existing.([]interface{})
+			patchArray, patchIsArray := patch.([]interface{})
+			if !userArray || !patchIsArray {
+				continue
+			}
+			values[topKey] = mergeNamedHelmValuesArrays(existingArray, patchArray)
 			continue
 		}
 		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
@@ -47,4 +89,27 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		}
 	}
 	return nil
+}
+
+// mergeNamedHelmValuesArrays appends patch items whose name is not already
+// present in the existing array, so user-defined entries win.
+func mergeNamedHelmValuesArrays(existing, additions []interface{}) []interface{} {
+	known := map[string]bool{}
+	for _, item := range existing {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			if name, _ := itemMap["name"].(string); name != "" {
+				known[name] = true
+			}
+		}
+	}
+	merged := append([]interface{}{}, existing...)
+	for _, item := range additions {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			if name, _ := itemMap["name"].(string); known[name] {
+				continue
+			}
+		}
+		merged = append(merged, item)
+	}
+	return merged
 }

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func testChart(name string) *chart.Chart {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{Name: name},
+		Values:   map[string]interface{}{},
+	}
+}
+
+func TestHelmChartAdapterInjectsNodePort(t *testing.T) {
+	for _, app := range []string{"grafana", "pgadmin4", "n8n", "superset", "nextcloud"} {
+		values, adjustments, err := prepareHelmInstallValues(testChart(app), "https://example.com/charts", map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("%s: %v", app, err)
+		}
+		service, ok := values["service"].(map[string]interface{})
+		if !ok || service["type"] != "NodePort" {
+			t.Errorf("%s: expected service.type NodePort, got %#v", app, values["service"])
+		}
+		if adjustments.legacyImages || adjustments.tomcatDefaultWebapps {
+			t.Errorf("%s: non-Bitnami chart should not apply Bitnami adjustments", app)
+		}
+	}
+}
+
+func TestHelmChartAdapterRespectsExplicitServiceType(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"service": map[string]interface{}{"type": "LoadBalancer"},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "LoadBalancer" {
+		t.Errorf("expected user service.type LoadBalancer preserved, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterSkipsUnregisteredChart(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("some-other-app"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	if _, exists := values["service"]; exists {
+		t.Errorf("unregistered chart should not be patched, got %#v", values["service"])
+	}
+}
+
+func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
+	values, adjustments, err := prepareHelmInstallValues(testChart("grafana"), bitnamiChartRepoURL, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("grafana should get NodePort even on Bitnami repo, got %#v", values["service"])
+	}
+	_ = adjustments
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -63,3 +63,70 @@ func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
 	}
 	_ = adjustments
 }
+
+func TestN8nAdapterInjectsSecureCookieEnv(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	env, ok := values["env"].([]interface{})
+	if !ok || len(env) != 1 {
+		t.Fatalf("expected injected env entry, got %#v", values["env"])
+	}
+	entry, _ := env[0].(map[string]interface{})
+	if entry["name"] != "N8N_SECURE_COOKIE" || entry["value"] != "false" {
+		t.Errorf("unexpected env entry: %#v", entry)
+	}
+}
+
+func TestN8nAdapterMergesUserEnvByName(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"env": []interface{}{
+			map[string]interface{}{"name": "TZ", "value": "Asia/Shanghai"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	env, ok := values["env"].([]interface{})
+	if !ok || len(env) != 2 {
+		t.Fatalf("expected 2 merged env entries, got %#v", values["env"])
+	}
+	names := map[string]string{}
+	for _, item := range env {
+		m, _ := item.(map[string]interface{})
+		names[m["name"].(string)] = m["value"].(string)
+	}
+	if names["TZ"] != "Asia/Shanghai" || names["N8N_SECURE_COOKIE"] != "false" {
+		t.Errorf("unexpected merged env: %#v", names)
+	}
+}
+
+func TestN8nAdapterUserEnvWinsByName(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("n8n"), "https://example.com/charts", map[string]interface{}{
+		"env": []interface{}{
+			map[string]interface{}{"name": "N8N_SECURE_COOKIE", "value": "true"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	env, _ := values["env"].([]interface{})
+	if len(env) != 1 {
+		t.Fatalf("expected single user env entry, got %#v", values["env"])
+	}
+	entry, _ := env[0].(map[string]interface{})
+	if entry["value"] != "true" {
+		t.Errorf("user value should win, got %#v", entry)
+	}
+}
+
+func TestGetHelmChartAdapterVisibleOverrides(t *testing.T) {
+	overrides := GetHelmChartAdapterVisibleOverrides("n8n")
+	if len(overrides) != 1 || overrides[0].Key != "env.N8N_SECURE_COOKIE" || overrides[0].Default != "false" {
+		t.Fatalf("unexpected visible overrides: %#v", overrides)
+	}
+	if got := GetHelmChartAdapterVisibleOverrides("grafana"); got != nil {
+		t.Errorf("grafana should have no visible overrides, got %#v", got)
+	}
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -130,3 +130,24 @@ func TestGetHelmChartAdapterVisibleOverrides(t *testing.T) {
 		t.Errorf("grafana should have no visible overrides, got %#v", got)
 	}
 }
+
+func TestApplyHelmChartAdapterOverrides(t *testing.T) {
+	values := map[string]interface{}{}
+	ApplyHelmChartAdapterOverrides("n8n", values, map[string]string{"env.N8N_SECURE_COOKIE": "true"})
+	env, _ := values["env"].([]interface{})
+	if len(env) != 1 {
+		t.Fatalf("expected applied env patch, got %#v", values)
+	}
+	entry, _ := env[0].(map[string]interface{})
+	if entry["value"] != "true" {
+		t.Errorf("expected user value true, got %#v", entry)
+	}
+}
+
+func TestApplyHelmChartAdapterOverridesIgnoresUnknown(t *testing.T) {
+	values := map[string]interface{}{}
+	ApplyHelmChartAdapterOverrides("n8n", values, map[string]string{"bogus.key": "x"})
+	if len(values) != 0 {
+		t.Errorf("unknown override should be ignored, got %#v", values)
+	}
+}

--- a/store/helm.go
+++ b/store/helm.go
@@ -1346,14 +1346,14 @@ func newHelmErrorEvent(err error) HelmInstallStreamEvent {
 // request. Lifecycle persistence is supplied by the caller so store remains
 // independent of the database layer.
 func InstallHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML string) <-chan HelmInstallStreamEvent {
-	return installHelmChartStream(ctx, lifecycle, cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, "")
+	return installHelmChartStream(ctx, lifecycle, cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, "", nil)
 }
 
-func InstallHelmChartStreamWithValuesBaseline(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) <-chan HelmInstallStreamEvent {
-	return installHelmChartStream(ctx, lifecycle, cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML)
+func InstallHelmChartStreamWithValuesBaseline(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string, adapterOverrides map[string]string) <-chan HelmInstallStreamEvent {
+	return installHelmChartStream(ctx, lifecycle, cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML, adapterOverrides)
 }
 
-func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) <-chan HelmInstallStreamEvent {
+func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle, cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string, adapterOverrides map[string]string) <-chan HelmInstallStreamEvent {
 	eventCh := make(chan HelmInstallStreamEvent, 64)
 	if lifecycle == nil {
 		eventCh <- newHelmErrorEvent(errors.New("Helm install lifecycle is required"))
@@ -1443,6 +1443,7 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 			finishWithError(err, "values preparation error")
 			return
 		}
+		ApplyHelmChartAdapterOverrides(helmChart.Name(), vals, adapterOverrides)
 		for _, warning := range adjustments.warnings() {
 			sendWarning(warning)
 		}

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -115,10 +115,24 @@ func prepareHelmInstallValues(ch *chart.Chart, repoURL string, input map[string]
 
 func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	values := cloneHelmValues(input)
-	if ch == nil || !isBitnamiCommunityChartRepo(repoURL) {
+	if ch == nil {
 		return values, helmInstallValueAdjustments{}, nil
 	}
+	adjustments := helmInstallValueAdjustments{}
+	if isBitnamiCommunityChartRepo(repoURL) {
+		bitnamiValues, bitnamiAdjustments, err := applyBitnamiChartAdjustments(ch, repoURL, values, input, inputIsOverrides)
+		if err != nil {
+			return nil, bitnamiAdjustments, err
+		}
+		values, adjustments = bitnamiValues, bitnamiAdjustments
+	}
+	if err := applyHelmChartAdapter(ch, values, input); err != nil {
+		return nil, adjustments, err
+	}
+	return values, adjustments, nil
+}
 
+func applyBitnamiChartAdjustments(ch *chart.Chart, repoURL string, values, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	coalesced, err := chartutil.CoalesceValues(ch, cloneHelmValues(input))
 	if err != nil {
 		return nil, helmInstallValueAdjustments{}, fmt.Errorf("coalesce Helm install values: %w", err)

--- a/web/src/HelmInstallModal.form.test.js
+++ b/web/src/HelmInstallModal.form.test.js
@@ -56,6 +56,7 @@ describe("HelmInstallModal form initialization", () => {
       resolveNamespaces = resolve;
     }));
     HelmBackend.getHelmChartValues.mockResolvedValue({status: "ok", data: ""});
+    HelmBackend.getHelmChartAdaptations.mockResolvedValue({status: "ok", data: []});
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);

--- a/web/src/HelmInstallModal.js
+++ b/web/src/HelmInstallModal.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState} from "react";
-import {Alert, Button, Form, Input, Modal, Select, Spin, Typography} from "antd";
+import {Alert, Button, Collapse, Form, Input, Modal, Select, Spin, Typography} from "antd";
 import {useTranslation} from "react-i18next";
 import * as HelmBackend from "./backend/HelmBackend";
 import * as NamespaceBackend from "./backend/NamespaceBackend";
@@ -24,6 +24,8 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
   const [namespaces, setNamespaces] = useState([]);
   const [valuesYAML, setValuesYAML] = useState("");
   const [valuesBaselineYAML, setValuesBaselineYAML] = useState("");
+  const [adaptationOverrides, setAdaptationOverrides] = useState([]);
+  const [adaptationValues, setAdaptationValues] = useState({});
   const [valuesLoading, setValuesLoading] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [pollingPaused, setPollingPaused] = useState(false);
@@ -235,6 +237,15 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
         .finally(() => {
           if (isCurrentInitialization()) {setValuesLoading(false);}
         });
+      HelmBackend.getHelmChartAdaptations(chart.chartName)
+        .then(res => {
+          if (!isCurrentInitialization()) {return;}
+          const overrides = res.status === "ok" && Array.isArray(res.data) ? res.data : [];
+          setAdaptationOverrides(overrides);
+          const defaults = {};
+          overrides.forEach(o => {defaults[o.key] = o.default;});
+          setAdaptationValues(defaults);
+        });
     }
   }, [open, chart, form]);
 
@@ -268,6 +279,8 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
     form.resetFields();
     setValuesYAML("");
     setValuesBaselineYAML("");
+    setAdaptationOverrides([]);
+    setAdaptationValues({});
     setError(null);
     setStorageWarning(null);
     setLogs([]);
@@ -275,6 +288,16 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
     setInstalling(false);
     setPollingPaused(false);
     onClose();
+  };
+
+  const changedAdaptationValues = () => {
+    const changed = {};
+    adaptationOverrides.forEach(o => {
+      if (adaptationValues[o.key] !== o.default) {
+        changed[o.key] = adaptationValues[o.key];
+      }
+    });
+    return changed;
   };
 
   const handleOk = () => {
@@ -317,6 +340,7 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
           version: values.version || chart.version,
           valuesYAML,
           valuesBaselineYAML,
+          adapterOverrides: changedAdaptationValues(),
         },
         line => {
           if (!mountedRef.current || streamAbortRef.current !== streamController) {return;}
@@ -526,6 +550,29 @@ export default function HelmInstallModal({open, chart, onClose, onInstalled}) {
         </Form>
       )}
 
+      {adaptationOverrides.length > 0 && (
+        <Collapse
+          ghost
+          style={{marginTop: 4}}
+          items={[{
+            key: "advanced",
+            label: t("helm:Advanced settings"),
+            children: adaptationOverrides.map(o => (
+              <Form.Item
+                key={o.key}
+                label={o.label}
+                extra={o.description}
+                style={{marginBottom: 12}}
+              >
+                <Input
+                  value={adaptationValues[o.key]}
+                  onChange={e => setAdaptationValues(prev => ({...prev, [o.key]: e.target.value}))}
+                />
+              </Form.Item>
+            )),
+          }]}
+        />
+      )}
       {showLog && (
         <div
           style={{

--- a/web/src/backend/HelmBackend.js
+++ b/web/src/backend/HelmBackend.js
@@ -38,6 +38,13 @@ export function getHelmChartValues(chart, repo, version) {
   ).then(r => r.json());
 }
 
+export function getHelmChartAdaptations(chart) {
+  return fetch(
+    `${Setting.ServerUrl}/api/get-helm-chart-adaptations?chart=${encodeURIComponent(chart)}`,
+    {credentials: "include", headers: lang()}
+  ).then(r => r.json());
+}
+
 export function getHelmReleases(namespace = "all") {
   return fetch(`${Setting.ServerUrl}/api/get-helm-releases?namespace=${namespace}`, {
     credentials: "include", headers: lang(),

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -119,7 +119,8 @@
     "Kubernetes API unavailable": "The Kubernetes API is unavailable. Check the control plane and network connection.",
     "Helm dry run failed": "The Helm preflight check failed. Check the chart templates, values, and error details.",
     "Missing resource": "Missing resource",
-    "Compatibility details": "Details"
+    "Compatibility details": "Details",
+    "Advanced settings": "Advanced settings"
   },
   "monitor": {
     "Abnormal Pods": "Abnormal Pods",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -119,7 +119,8 @@
     "Kubernetes API unavailable": "Kubernetes API 当前不可用，请检查控制面状态和网络连接。",
     "Helm dry run failed": "Helm 预检失败，请检查 Chart 模板、values 和错误详情。",
     "Missing resource": "缺少资源",
-    "Compatibility details": "详细信息"
+    "Compatibility details": "详细信息",
+    "Advanced settings": "高级设置"
   },
   "monitor": {
     "Abnormal Pods": "异常 Pod",


### PR DESCRIPTION
## What

Backend: visible adapter overrides now carry a `valuesPatch`; the install stream accepts `adapterOverrides` and applies user-chosen values onto the install values (unknown keys ignored).

Frontend: the install form fetches `/api/get-helm-chart-adaptations`, shows an `Advanced settings` collapse with the chart's adjustable overrides (pre-filled with adapter defaults, e.g. n8n `N8N_SECURE_COOKIE`), and submits only the values the user changed from default.

Stacks on #130, #131 (visible overrides API).

## Why

Issue #121: security-related adapter defaults (e.g. secure cookie off) are a downgrade and should not be silently injected — this exposes them as adjustable options in the install form while keeping defaults usable out of the box.

## Scope

- `store/adapters.go` — `ValuesPatch` on visible overrides, `ApplyHelmChartAdapterOverrides`
- `store/helm.go` — install stream applies overrides
- `controllers/helm.go` — `adapterOverrides` on the install request
- `web/src/backend/HelmBackend.js` — `getHelmChartAdaptations`
- `web/src/HelmInstallModal.js` — advanced settings collapse, changed-values-only submit
- `web/src/HelmInstallModal.form.test.js` — mock the new API
- locales en/zh — "Advanced settings"

## Verification

`go build`, `go vet`, `gofmt` clean; 2 new backend tests; web eslint clean; 22 frontend tests pass.