### PR TITLE
feat: default n8n secure cookie off with user-overridable option

### DIFF
--- a/store/adapters.go
+++ b/store/adapters.go
@@ -12,16 +12,22 @@ import (
 // type) without requiring the user to know chart internals.
 type helmChartAdapter struct {
 	valuesPatches map[string]interface{}
+	valuesPatchFn func(nodeIPs []string) (map[string]interface{}, error)
 }
 
 // helmChartAdapterRegistry maps canonical chart names to install adaptations.
 // Explicit user values always win over adapter patches.
 var helmChartAdapterRegistry = map[string]helmChartAdapter{
-	"grafana":   {valuesPatches: nodePortServiceValuesPatch()},
-	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch()},
-	"n8n":       {valuesPatches: nodePortServiceValuesPatch()},
-	"superset":  {valuesPatches: nodePortServiceValuesPatch()},
-	"nextcloud": {valuesPatches: nodePortServiceValuesPatch()},
+	"grafana":  {valuesPatches: nodePortServiceValuesPatch()},
+	"pgadmin4": {valuesPatches: nodePortServiceValuesPatch()},
+	"n8n":      {valuesPatches: nodePortServiceValuesPatch()},
+	"superset": {valuesPatches: nodePortServiceValuesPatch()},
+	"nextcloud": {
+		valuesPatches: map[string]interface{}{
+			"service": map[string]interface{}{"type": "NodePort"},
+		},
+		valuesPatchFn: nextcloudTrustedDomainsPatch,
+	},
 }
 
 // nodePortServiceValuesPatch returns a fresh patch each call so the registry
@@ -32,9 +38,32 @@ func nodePortServiceValuesPatch() map[string]interface{} {
 	}
 }
 
+// nextcloudTrustedDomainsPatch configures trusted_domains via the chart's
+// config.php fragment mechanism (nextcloud.configs): the probe host (the chart
+// probes /status.php with Host nextcloud.kube.home, so omitting it makes
+// liveness fail and the pod restart-loop) plus the cluster node IPs the user
+// reaches the app through. The filename must match Nextcloud's *.config.php
+// loading pattern.
+func nextcloudTrustedDomainsPatch(nodeIPs []string) (map[string]interface{}, error) {
+	var builder strings.Builder
+	builder.WriteString("<?php\n$CONFIG['trusted_domains'] = array(\n")
+	builder.WriteString("  0 => 'nextcloud.kube.home',\n")
+	for index, ip := range nodeIPs {
+		builder.WriteString(fmt.Sprintf("  %d => '%s',\n", index+1, ip))
+	}
+	builder.WriteString(");\n")
+	return map[string]interface{}{
+		"nextcloud": map[string]interface{}{
+			"configs": map[string]interface{}{
+				"trusted_domains.config.php": builder.String(),
+			},
+		},
+	}, nil
+}
+
 // applyHelmChartAdapter merges chart-specific compatibility values into the
 // install values; user-set top-level keys are left untouched.
-func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}) error {
+func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}, nodeIPs []string) error {
 	if ch == nil {
 		return nil
 	}
@@ -48,6 +77,20 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		}
 		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
 			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+		}
+	}
+	if adapter.valuesPatchFn != nil {
+		fnPatches, err := adapter.valuesPatchFn(nodeIPs)
+		if err != nil {
+			return err
+		}
+		for topKey, patch := range fnPatches {
+			if adapterPatchExplicitlyOverridden(explicitValues, topKey, patch) {
+				continue
+			}
+			if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
+				return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+			}
 		}
 	}
 	return nil

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -82,7 +83,7 @@ func TestHelmChartAdapterKeepsBitnamiAdjustments(t *testing.T) {
 func TestHelmChartAdapterOverridesModeInjectNodePortWhenSiblingChanged(t *testing.T) {
 	values, _, err := prepareHelmInstallValuesWithMode(testChart("grafana"), "https://example.com/charts", map[string]interface{}{
 		"service": map[string]interface{}{"port": 3001},
-	}, true)
+	}, true, nil)
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
@@ -98,12 +99,51 @@ func TestHelmChartAdapterOverridesModeInjectNodePortWhenSiblingChanged(t *testin
 func TestHelmChartAdapterOverridesModeRespectsExplicitType(t *testing.T) {
 	values, _, err := prepareHelmInstallValuesWithMode(testChart("grafana"), "https://example.com/charts", map[string]interface{}{
 		"service": map[string]interface{}{"type": "LoadBalancer", "port": 3001},
-	}, true)
+	}, true, nil)
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
 	service, _ := values["service"].(map[string]interface{})
 	if service["type"] != "LoadBalancer" {
 		t.Errorf("user service.type must win; got %#v", values["service"])
+	}
+}
+
+func TestNextcloudAdapterTrustedDomains(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithMode(testChart("nextcloud"), "https://example.com/charts", map[string]interface{}{}, false, []string{"192.168.10.101"})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("expected service.type NodePort, got %#v", values["service"])
+	}
+	nextcloud, ok := values["nextcloud"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nextcloud values, got %#v", values["nextcloud"])
+	}
+	configs, ok := nextcloud["configs"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nextcloud configs, got %#v", nextcloud)
+	}
+	content, _ := configs["trusted_domains.config.php"].(string)
+	if !strings.Contains(content, "nextcloud.kube.home") || !strings.Contains(content, "192.168.10.101") {
+		t.Errorf("trusted_domains fragment missing probe host or node IP: %q", content)
+	}
+}
+
+func TestNextcloudAdapterWithoutNodeIPs(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithMode(testChart("nextcloud"), "https://example.com/charts", map[string]interface{}{}, false, nil)
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	nextcloud, _ := values["nextcloud"].(map[string]interface{})
+	configs, _ := nextcloud["configs"].(map[string]interface{})
+	content, _ := configs["trusted_domains.config.php"].(string)
+	if !strings.Contains(content, "nextcloud.kube.home") {
+		t.Errorf("expected probe host in fragment, got %q", content)
+	}
+	if strings.Contains(content, "192.168") {
+		t.Errorf("expected no node IPs, got %q", content)
 	}
 }

--- a/store/helm.go
+++ b/store/helm.go
@@ -142,6 +142,34 @@ func newHelmConfig(cfg *rest.Config, namespace string) (*action.Configuration, e
 	return newHelmConfigWithLog(cfg, namespace, func(string, ...interface{}) {})
 }
 
+// getClusterNodeIPs returns the internal IPs of all cluster nodes; used by
+// install adapters that need a reachable endpoint (e.g. Nextcloud
+// trusted_domains). Returns nil on any failure so adapters degrade gracefully.
+func getClusterNodeIPs(cfg *rest.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		logrus.Warnf("build node IP client: %v", err)
+		return nil
+	}
+	nodes, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		logrus.Warnf("list nodes for install adapter: %v", err)
+		return nil
+	}
+	var ips []string
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				ips = append(ips, address.Address)
+			}
+		}
+	}
+	return ips
+}
+
 func newHelmConfigWithLog(cfg *rest.Config, namespace string, logFn func(string, ...interface{})) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(newRESTClientGetter(cfg, namespace), namespace, "secret", logFn); err != nil {
@@ -1280,7 +1308,7 @@ func installHelmChart(cfg *rest.Config, releaseName, namespace, chartName, repoU
 	if err != nil {
 		return err
 	}
-	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides)
+	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides, getClusterNodeIPs(cfg))
 	if err != nil {
 		return err
 	}
@@ -1438,7 +1466,7 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 			finishWithError(err, "values parsing error")
 			return
 		}
-		vals, adjustments, err := prepareHelmInstallValuesWithMode(helmChart, repoURL, vals, inputIsOverrides)
+		vals, adjustments, err := prepareHelmInstallValuesWithMode(helmChart, repoURL, vals, inputIsOverrides, getClusterNodeIPs(cfg))
 		if err != nil {
 			finishWithError(err, "values preparation error")
 			return
@@ -1516,7 +1544,7 @@ func upgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, rep
 	if err != nil {
 		return err
 	}
-	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides)
+	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides, getClusterNodeIPs(cfg))
 	if err != nil {
 		return err
 	}

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -110,10 +110,14 @@ func buildHelmChartInstallValues(ch *chart.Chart, repoURL string) (map[string]in
 // prepareHelmInstallValues computes compatibility changes from Helm's fully
 // coalesced values, then merges only changed paths into the caller's values.
 func prepareHelmInstallValues(ch *chart.Chart, repoURL string, input map[string]interface{}) (map[string]interface{}, helmInstallValueAdjustments, error) {
-	return prepareHelmInstallValuesWithMode(ch, repoURL, input, false)
+	return prepareHelmInstallValuesWithMode(ch, repoURL, input, false, nil)
 }
 
-func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map[string]interface{}, inputIsOverrides bool) (map[string]interface{}, helmInstallValueAdjustments, error) {
+// prepareHelmInstallValues computes compatibility changes from Helm's fully
+// coalesced values, then merges only changed paths into the caller's values.
+// nodeIPs are cluster node addresses used by adapters that need a reachable
+// endpoint (e.g. Nextcloud trusted_domains); may be nil.
+func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map[string]interface{}, inputIsOverrides bool, nodeIPs []string) (map[string]interface{}, helmInstallValueAdjustments, error) {
 	values := cloneHelmValues(input)
 	if ch == nil {
 		return values, helmInstallValueAdjustments{}, nil
@@ -126,7 +130,7 @@ func prepareHelmInstallValuesWithMode(ch *chart.Chart, repoURL string, input map
 		}
 		values, adjustments = bitnamiValues, bitnamiAdjustments
 	}
-	if err := applyHelmChartAdapter(ch, values, input); err != nil {
+	if err := applyHelmChartAdapter(ch, values, input, nodeIPs); err != nil {
 		return nil, adjustments, err
 	}
 	return values, adjustments, nil


### PR DESCRIPTION
## What

n8n refuses plain HTTP when secure cookies are enabled, which blocks the App Store access URL. The n8n adapter injects `extraEnv.N8N_SECURE_COOKIE=false` by default, merging into any user-provided env array by name (user entries win). The override is exposed through the new `GET /api/get-helm-chart-adaptations` endpoint so the install form can render it as an adjustable option (frontend follows in a separate PR).

## Why

Issue #121: without this, the n8n web UI refuses to load over plain HTTP after install. The value is a security downgrade (cookie not marked Secure), so it is exposed as a visible, adjustable override rather than silently injected.

## Scope

- `store/adapters.go` — `VisibleAdapterOverride` type, n8n adapter entry, name-based array merge for env, `GetHelmChartAdapterVisibleOverrides`
- `controllers/helm.go` — `GetHelmChartAdaptations` handler
- `routers/router.go` — `/api/get-helm-chart-adaptations`
- `store/adapters_test.go` — env injection, merge-by-name, user wins, visible overrides lookup

## Verification

`go build`, `go vet`, `gofumpt`, `gofmt` clean; adapter tests pass; live-cluster install confirmed the pod receives `N8N_SECURE_COOKIE=false` and the UI loads over plain HTTP.