### PR TITLE
feat: generate Superset SECRET_KEY and install psycopg2 at pod start

### DIFF
--- a/store/adapters.go
+++ b/store/adapters.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -12,15 +14,25 @@ import (
 // type) without requiring the user to know chart internals.
 type helmChartAdapter struct {
 	valuesPatches map[string]interface{}
+	valuesPatchFn func() (map[string]interface{}, error)
 }
 
 // helmChartAdapterRegistry maps canonical chart names to install adaptations.
 // Explicit user values always win over adapter patches.
 var helmChartAdapterRegistry = map[string]helmChartAdapter{
-	"grafana":   {valuesPatches: nodePortServiceValuesPatch()},
-	"pgadmin4":  {valuesPatches: nodePortServiceValuesPatch()},
-	"n8n":       {valuesPatches: nodePortServiceValuesPatch()},
-	"superset":  {valuesPatches: nodePortServiceValuesPatch()},
+	"grafana":  {valuesPatches: nodePortServiceValuesPatch()},
+	"pgadmin4": {valuesPatches: nodePortServiceValuesPatch()},
+	"n8n":      {valuesPatches: nodePortServiceValuesPatch()},
+	"superset": {
+		valuesPatches: map[string]interface{}{
+			"service": map[string]interface{}{
+				"type":     "NodePort",
+				"nodePort": map[string]interface{}{"http": 30088},
+			},
+			"bootstrapScript": supersetBootstrapScript,
+		},
+		valuesPatchFn: supersetConfigOverridesPatch,
+	},
 	"nextcloud": {valuesPatches: nodePortServiceValuesPatch()},
 }
 
@@ -30,6 +42,25 @@ func nodePortServiceValuesPatch() map[string]interface{} {
 	return map[string]interface{}{
 		"service": map[string]interface{}{"type": "NodePort"},
 	}
+}
+
+// supersetBootstrapScript installs the psycopg2 driver into a writable target
+// dir at pod start: the apache/superset image has no psycopg2, the app venv
+// has no pip, and the system python (/usr/local/bin/python3) does. ${...}
+// keeps the shell expansion out of Helm's tpl processing.
+const supersetBootstrapScript = "/usr/local/bin/python3 -m pip install --no-cache-dir --target /tmp/pgdrivers psycopg2-binary && export PYTHONPATH=/tmp/pgdrivers:${PYTHONPATH}"
+
+// supersetConfigOverridesPatch generates a random SECRET_KEY: the default
+// value makes Superset refuse to start. The configOverrides template emits
+// the raw value, so the patch is a complete Python assignment.
+func supersetConfigOverridesPatch() (map[string]interface{}, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("generate Superset SECRET_KEY: %w", err)
+	}
+	return map[string]interface{}{
+		"configOverrides": map[string]interface{}{"secret": fmt.Sprintf("SECRET_KEY = %q", hex.EncodeToString(buf))},
+	}, nil
 }
 
 // applyHelmChartAdapter merges chart-specific compatibility values into the
@@ -48,6 +79,20 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		}
 		if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
 			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+		}
+	}
+	if adapter.valuesPatchFn != nil {
+		fnPatches, err := adapter.valuesPatchFn()
+		if err != nil {
+			return err
+		}
+		for topKey, patch := range fnPatches {
+			if adapterPatchExplicitlyOverridden(explicitValues, topKey, patch) {
+				continue
+			}
+			if err := mergeHelmValueOverrides(values, map[string]interface{}{topKey: patch}, nil); err != nil {
+				return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+			}
 		}
 	}
 	return nil

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -112,6 +112,7 @@ func TestHelmChartAdapterOverridesModeRespectsExplicitType(t *testing.T) {
 		t.Errorf("user service.type must win; got %#v", values["service"])
 	}
 }
+
 func TestSupersetAdapterPatches(t *testing.T) {
 	values, _, err := prepareHelmInstallValues(testChart("superset"), "https://example.com/charts", map[string]interface{}{})
 	if err != nil {
@@ -153,7 +154,6 @@ func TestSupersetAdapterRespectsUserSecret(t *testing.T) {
 }
 
 func TestReuseSupersetSecretKeyOnUpgrade(t *testing.T) {
-
 	cfg := &action.Configuration{}
 	mem := driver.NewMemory()
 	cfg.Releases = storage.Init(mem)

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -1,9 +1,14 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 func testChart(name string) *chart.Chart {
@@ -105,5 +110,76 @@ func TestHelmChartAdapterOverridesModeRespectsExplicitType(t *testing.T) {
 	service, _ := values["service"].(map[string]interface{})
 	if service["type"] != "LoadBalancer" {
 		t.Errorf("user service.type must win; got %#v", values["service"])
+	}
+}
+func TestSupersetAdapterPatches(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("superset"), "https://example.com/charts", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("expected service.type NodePort, got %#v", values["service"])
+	}
+	nodePort, _ := service["nodePort"].(map[string]interface{})
+	if nodePort["http"] != 30088 {
+		t.Errorf("expected explicit numeric nodePort, got %#v", service["nodePort"])
+	}
+	overrides, ok := values["configOverrides"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected configOverrides, got %#v", values["configOverrides"])
+	}
+	secret, _ := overrides["secret"].(string)
+	if !strings.HasPrefix(secret, "SECRET_KEY = ") || len(secret) < 32 {
+		t.Errorf("expected SECRET_KEY assignment, got %q", secret)
+	}
+	bootstrap, _ := values["bootstrapScript"].(string)
+	if !strings.Contains(bootstrap, "psycopg2") {
+		t.Errorf("expected psycopg2 in bootstrapScript, got %q", bootstrap)
+	}
+}
+
+func TestSupersetAdapterRespectsUserSecret(t *testing.T) {
+	values, _, err := prepareHelmInstallValues(testChart("superset"), "https://example.com/charts", map[string]interface{}{
+		"configOverrides": map[string]interface{}{"secret": "user-secret"},
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	overrides, _ := values["configOverrides"].(map[string]interface{})
+	if overrides["secret"] != "user-secret" {
+		t.Errorf("user SECRET_KEY should win, got %#v", overrides["secret"])
+	}
+}
+
+func TestReuseSupersetSecretKeyOnUpgrade(t *testing.T) {
+
+	cfg := &action.Configuration{}
+	mem := driver.NewMemory()
+	cfg.Releases = storage.Init(mem)
+	chart := &chart.Chart{Metadata: &chart.Metadata{Name: "superset"}}
+	if err := mem.Create("superset-demo", &release.Release{
+		Name:  "superset-demo",
+		Chart: chart,
+		Info:  &release.Info{Status: release.StatusDeployed},
+		Config: map[string]interface{}{
+			"configOverrides": map[string]interface{}{"secret": "old-secret"},
+		},
+	}); err != nil {
+		t.Fatalf("seed release: %v", err)
+	}
+
+	vals := map[string]interface{}{}
+	reuseSupersetSecretKey(cfg, "superset-demo", vals)
+	overrides, _ := vals["configOverrides"].(map[string]interface{})
+	if overrides["secret"] != "old-secret" {
+		t.Fatalf("expected existing SECRET_KEY reused, got %#v", vals["configOverrides"])
+	}
+
+	vals2 := map[string]interface{}{"configOverrides": map[string]interface{}{"secret": "user-key"}}
+	reuseSupersetSecretKey(cfg, "superset-demo", vals2)
+	overrides2, _ := vals2["configOverrides"].(map[string]interface{})
+	if overrides2["secret"] != "user-key" {
+		t.Fatalf("user-provided SECRET_KEY must win, got %#v", vals2["configOverrides"])
 	}
 }

--- a/store/helm.go
+++ b/store/helm.go
@@ -1499,6 +1499,37 @@ func UpgradeHelmReleaseWithValuesBaseline(cfg *rest.Config, releaseName, namespa
 	return upgradeHelmRelease(cfg, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML)
 }
 
+// reuseSupersetSecretKey carries the installed Superset SECRET_KEY into an
+// upgrade. The adapter only generates a key when none is set; an upgrade that
+// regenerated it would invalidate all encrypted data (DB credentials, saved
+// dashboard ciphertext). Harmless for charts without configOverrides.secret.
+func reuseSupersetSecretKey(actionConfig *action.Configuration, releaseName string, vals map[string]interface{}) {
+	release, err := actionConfig.Releases.Last(releaseName)
+	if err != nil || release == nil || release.Chart == nil {
+		return
+	}
+	coalesced, err := chartutil.CoalesceValues(release.Chart, release.Config)
+	if err != nil {
+		return
+	}
+	overrides, ok := coalesced["configOverrides"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	secret, ok := overrides["secret"].(string)
+	if !ok || secret == "" {
+		return
+	}
+	switch existing := vals["configOverrides"].(type) {
+	case nil:
+		vals["configOverrides"] = map[string]interface{}{"secret": secret}
+	case map[string]interface{}:
+		if _, has := existing["secret"]; !has {
+			existing["secret"] = secret
+		}
+	}
+}
+
 func upgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, repoURL, version, valuesYAML, valuesBaselineYAML string) error {
 	actionConfig, err := newHelmConfig(cfg, namespace)
 	if err != nil {
@@ -1516,6 +1547,7 @@ func upgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, rep
 	if err != nil {
 		return err
 	}
+	reuseSupersetSecretKey(actionConfig, releaseName, vals)
 	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

Superset refuses to start with its default SECRET_KEY and the apache/superset image ships no psycopg2 driver, so a PostgreSQL metadata database fails with ModuleNotFoundError. The superset adapter injects:

- a random `configOverrides.secret` per install — a complete Python assignment (`SECRET_KEY = "..."`), because the chart template emits raw values
- a `bootstrapScript` that pip-installs `psycopg2-binary` into a writable `/tmp` target using the system python (`/usr/local/bin/python3`, the app venv has no pip)

Upgrade stability: `reuseSupersetSecretKey` carries the installed SECRET_KEY into upgrades so encrypted data stays valid; user-provided keys win.

## Why

Issue #121: without these, Superset's pods never become ready (refuses to start / missing driver), leaving the install stuck. The service patch also injects an explicit numeric nodePort (30088) because the chart default `nodePort.http: nil` renders as the string "nil", which k8s rejects for NodePort services.

## Scope

- `store/adapters.go` — `valuesPatchFn`, superset adapter entry, `supersetConfigOverridesPatch`, `supersetBootstrapScript`
- `store/helm.go` — `reuseSupersetSecretKey`, called on upgrade
- `store/adapters_test.go` — patch injection, user-value priority, SECRET_KEY reuse

## Verification

`go build`, `go vet`, `gofumpt`, `gofmt` clean; adapter tests pass; live install confirmed ready pods (no CrashLoopBackOff), init job created the admin user, HTTP 200 on login.