### PR TITLE
refactor: replace Nextcloud PHP generation with generic endpoint binding

### DIFF
--- a/store/adapters.go
+++ b/store/adapters.go
@@ -14,14 +14,19 @@ import (
 // helmChartAdapter encodes app-aware install value patches keyed by chart name.
 // It makes an app usable right after installation (e.g. a reachable service
 // type) without requiring the user to know chart internals.
+type helmEndpointBinding struct {
+	valuesPath  []string
+	hostPath    []string
+	sourcePaths [][]string
+	defaultHost string
+}
+
 type helmChartAdapter struct {
 	valuesPatches map[string]interface{}
 	// generatedValuesPatchFn mints per-install values such as a random secret.
 	// The values preview skips it so the install dialog stays reproducible.
 	generatedValuesPatchFn func(explicitValues map[string]interface{}) (map[string]interface{}, error)
-	// clusterPatchFn mints patches that need cluster context (chart defaults,
-	// node IPs), e.g. Nextcloud trusted_domains. Skipped for the preview.
-	clusterPatchFn func(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) (map[string]interface{}, error)
+	endpointBindings []helmEndpointBinding
 	// preservedValuePaths are carried over from the installed release on upgrade.
 	preservedValuePaths [][]string
 }
@@ -38,8 +43,13 @@ var helmChartAdapterRegistry = map[string]helmChartAdapter{
 		preservedValuePaths:    supersetPreservedValuePaths,
 	},
 	"nextcloud": {
-		valuesPatches:  nodePortServiceValuesPatch(),
-		clusterPatchFn: nextcloudTrustedDomainsPatch,
+		valuesPatches: nodePortServiceValuesPatch(),
+		endpointBindings: []helmEndpointBinding{{
+			valuesPath:  []string{"nextcloud", "trustedDomains"},
+			hostPath:    []string{"nextcloud", "host"},
+			sourcePaths: [][]string{{"nextcloud", "trustedDomains"}, {"httpRoute", "hostnames"}},
+			defaultHost: "nextcloud.kube.home",
+		}},
 	},
 }
 
@@ -124,6 +134,85 @@ func supersetSecretKeyAlreadySet(values map[string]interface{}) bool {
 	return ok && strings.TrimSpace(secret) != ""
 }
 
+func applyHelmEndpointBindings(ch *chart.Chart, values map[string]interface{}, bindings []helmEndpointBinding, nodeIPs []string) {
+	for _, binding := range bindings {
+		domains := []string{"localhost"}
+		if host, ok := helmValueAtPath(values, binding.hostPath).(string); ok && strings.TrimSpace(host) != "" {
+			domains = append(domains, host)
+		} else if host, ok := helmValueAtPath(ch.Values, binding.hostPath).(string); ok && strings.TrimSpace(host) != "" {
+			domains = append(domains, host)
+		} else if binding.defaultHost != "" {
+			domains = append(domains, binding.defaultHost)
+		}
+		for _, path := range binding.sourcePaths {
+			domains = append(domains, helmStringValuesAtPath(values, path)...)
+			if ch != nil {
+				domains = append(domains, helmStringValuesAtPath(ch.Values, path)...)
+			}
+		}
+		domains = append(domains, nodeIPs...)
+		setHelmValueAtPath(values, binding.valuesPath, uniqueNonEmptyStrings(domains))
+	}
+}
+
+func helmValueAtPath(values map[string]interface{}, path []string) interface{} {
+	for index, key := range path {
+		value, ok := values[key]
+		if !ok {
+			return nil
+		}
+		if index == len(path)-1 {
+			return value
+		}
+		values, ok = value.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+	}
+	return nil
+}
+
+func helmStringValuesAtPath(values map[string]interface{}, path []string) []string {
+	value := helmValueAtPath(values, path)
+	var result []string
+	switch typed := value.(type) {
+	case []interface{}:
+		for _, item := range typed {
+			if text, ok := item.(string); ok {
+				result = append(result, text)
+			}
+		}
+	case []string:
+		result = append(result, typed...)
+	}
+	return result
+}
+
+func setHelmValueAtPath(values map[string]interface{}, path []string, value interface{}) {
+	for _, key := range path[:len(path)-1] {
+		next, ok := values[key].(map[string]interface{})
+		if !ok {
+			next = map[string]interface{}{}
+			values[key] = next
+		}
+		values = next
+	}
+	values[path[len(path)-1]] = value
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := map[string]bool{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" && !seen[value] {
+			seen[value] = true
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
 // applyHelmChartAdapter merges chart-specific compatibility values into the
 // install values; user-set top-level keys are left untouched.
 func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}, includeDynamic bool, nodeIPs func() []string) error {
@@ -136,23 +225,17 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 	}
 	patches := adapter.valuesPatches
 	if includeDynamic {
+		var ips []string
+		if nodeIPs != nil {
+			ips = nodeIPs()
+		}
+		applyHelmEndpointBindings(ch, values, adapter.endpointBindings, ips)
 		if adapter.generatedValuesPatchFn != nil {
 			generated, err := adapter.generatedValuesPatchFn(explicitValues)
 			if err != nil {
 				return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
 			}
 			patches = mergedHelmAdapterPatches(patches, generated)
-		}
-		if adapter.clusterPatchFn != nil {
-			var ips []string
-			if nodeIPs != nil {
-				ips = nodeIPs()
-			}
-			clusterPatches, err := adapter.clusterPatchFn(ch, values, ips)
-			if err != nil {
-				return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
-			}
-			patches = mergedHelmAdapterPatches(patches, clusterPatches)
 		}
 	}
 	for topKey, patch := range patches {
@@ -266,119 +349,4 @@ func adapterPatchExplicitlyOverridden(explicitValues map[string]interface{}, top
 		}
 	}
 	return false
-}
-
-// nextcloudTrustedDomainsPatch configures trusted_domains via the chart's
-// config.php fragment mechanism (nextcloud.configs). The fragment replaces
-// the key with the full domain list computed in Go: Nextcloud's loader resets
-// $CONFIG before every file and merges fragments at the top level, so a
-// fragment cannot append to values written by config.php.
-//
-// The probe host is resolved from the user values or the chart default
-// (nextcloud.host); the chart probes /status.php with that host, so omitting
-// it makes liveness fail and the pod restart-loop. Node IPs are the cluster
-// addresses the user reaches the app through; they are snapshotted at
-// install/upgrade time and refreshed on the next upgrade. Known gap: the
-// metrics service FQDN (<release>.<ns>.svc.cluster.local) is not included
-// because the adapter has no release/namespace context.
-func nextcloudTrustedDomainsPatch(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) (map[string]interface{}, error) {
-	domains := nextcloudTrustedDomainList(ch, values, nodeIPs)
-	var builder strings.Builder
-	builder.WriteString("<?php\n$CONFIG['trusted_domains'] = [\n")
-	for index, domain := range domains {
-		builder.WriteString(fmt.Sprintf("  %d => '%s',\n", index, escapePHPString(domain)))
-	}
-	builder.WriteString("];\n")
-	return map[string]interface{}{
-		"nextcloud": map[string]interface{}{
-			"configs": map[string]interface{}{
-				"trusted_domains.config.php": builder.String(),
-			},
-		},
-	}, nil
-}
-
-// nextcloudTrustedDomainList builds the full trusted_domains list: the probe
-// host, nextcloud.trustedDomains, httpRoute hostnames, localhost and the
-// cluster node IPs, deduplicated.
-func nextcloudTrustedDomainList(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) []string {
-	seen := map[string]bool{}
-	var domains []string
-	add := func(domain string) {
-		domain = strings.TrimSpace(domain)
-		if domain == "" || seen[domain] {
-			return
-		}
-		seen[domain] = true
-		domains = append(domains, domain)
-	}
-	add(nextcloudProbeHost(ch, values))
-	if nextcloud, ok := values["nextcloud"].(map[string]interface{}); ok {
-		for _, domain := range helmStringSlice(nextcloud["trustedDomains"]) {
-			add(domain)
-		}
-	}
-	if ch != nil && ch.Values != nil {
-		if defaultNextcloud, ok := ch.Values["nextcloud"].(map[string]interface{}); ok {
-			for _, domain := range helmStringSlice(defaultNextcloud["trustedDomains"]) {
-				add(domain)
-			}
-		}
-	}
-	for _, source := range []map[string]interface{}{values, ch.Values} {
-		if source == nil {
-			continue
-		}
-		if httpRoute, ok := source["httpRoute"].(map[string]interface{}); ok {
-			for _, domain := range helmStringSlice(httpRoute["hostnames"]) {
-				add(domain)
-			}
-		}
-	}
-	add("localhost")
-	for _, ip := range nodeIPs {
-		add(ip)
-	}
-	return domains
-}
-
-// helmStringSlice flattens a values field that may be []interface{} of strings
-// into a []string.
-func helmStringSlice(value interface{}) []string {
-	items, ok := value.([]interface{})
-	if !ok {
-		return nil
-	}
-	result := make([]string, 0, len(items))
-	for _, item := range items {
-		if text, ok := item.(string); ok {
-			result = append(result, text)
-		}
-	}
-	return result
-}
-
-// nextcloudProbeHost returns the effective nextcloud.host: the user-provided
-// value if set, else the chart default, else the historical probe host.
-func nextcloudProbeHost(ch *chart.Chart, values map[string]interface{}) string {
-	if nextcloud, ok := values["nextcloud"].(map[string]interface{}); ok {
-		if host, ok := nextcloud["host"].(string); ok && strings.TrimSpace(host) != "" {
-			return host
-		}
-	}
-	if ch != nil && ch.Values != nil {
-		if nextcloud, ok := ch.Values["nextcloud"].(map[string]interface{}); ok {
-			if host, ok := nextcloud["host"].(string); ok && strings.TrimSpace(host) != "" {
-				return host
-			}
-		}
-	}
-	return "nextcloud.kube.home"
-}
-
-// escapePHPString escapes a value for a PHP single-quoted string: backslashes
-// first (they escape the quote otherwise), then single quotes.
-func escapePHPString(value string) string {
-	value = strings.ReplaceAll(value, "\\", "\\\\")
-	return strings.ReplaceAll(value, "'", "\\'")
 }

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -26,7 +26,7 @@ type helmChartAdapter struct {
 	// generatedValuesPatchFn mints per-install values such as a random secret.
 	// The values preview skips it so the install dialog stays reproducible.
 	generatedValuesPatchFn func(explicitValues map[string]interface{}) (map[string]interface{}, error)
-	endpointBindings []helmEndpointBinding
+	endpointBindings       []helmEndpointBinding
 	// preservedValuePaths are carried over from the installed release on upgrade.
 	preservedValuePaths [][]string
 }

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -126,7 +126,7 @@ func supersetSecretKeyAlreadySet(values map[string]interface{}) bool {
 
 // applyHelmChartAdapter merges chart-specific compatibility values into the
 // install values; user-set top-level keys are left untouched.
-func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}, includeGenerated bool, nodeIPs func() []string) error {
+func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}, includeDynamic bool, nodeIPs func() []string) error {
 	if ch == nil {
 		return nil
 	}
@@ -135,7 +135,7 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		return nil
 	}
 	patches := adapter.valuesPatches
-	if includeGenerated {
+	if includeDynamic {
 		if adapter.generatedValuesPatchFn != nil {
 			generated, err := adapter.generatedValuesPatchFn(explicitValues)
 			if err != nil {
@@ -269,26 +269,26 @@ func adapterPatchExplicitlyOverridden(explicitValues map[string]interface{}, top
 }
 
 // nextcloudTrustedDomainsPatch configures trusted_domains via the chart's
-// config.php fragment mechanism (nextcloud.configs). The fragment APPENDS to
-// any existing trusted_domains (chart defaults, metrics service names, user
-// ingress domains) instead of overwriting them.
+// config.php fragment mechanism (nextcloud.configs). The fragment replaces
+// the key with the full domain list computed in Go: Nextcloud's loader resets
+// $CONFIG before every file and merges fragments at the top level, so a
+// fragment cannot append to values written by config.php.
 //
 // The probe host is resolved from the user values or the chart default
 // (nextcloud.host); the chart probes /status.php with that host, so omitting
 // it makes liveness fail and the pod restart-loop. Node IPs are the cluster
 // addresses the user reaches the app through; they are snapshotted at
-// install/upgrade time and refreshed on the next upgrade.
-//
-// The filename must match Nextcloud's *.config.php loading pattern, and this
-// fragment loads last (natsort), so $CONFIG already holds prior entries.
+// install/upgrade time and refreshed on the next upgrade. Known gap: the
+// metrics service FQDN (<release>.<ns>.svc.cluster.local) is not included
+// because the adapter has no release/namespace context.
 func nextcloudTrustedDomainsPatch(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) (map[string]interface{}, error) {
+	domains := nextcloudTrustedDomainList(ch, values, nodeIPs)
 	var builder strings.Builder
-	builder.WriteString("<?php\n$CONFIG['trusted_domains'] = array_merge($CONFIG['trusted_domains'] ?? [], [\n")
-	builder.WriteString(fmt.Sprintf("  0 => '%s',\n", escapePHPString(nextcloudProbeHost(ch, values))))
-	for index, ip := range nodeIPs {
-		builder.WriteString(fmt.Sprintf("  %d => '%s',\n", index+1, escapePHPString(ip)))
+	builder.WriteString("<?php\n$CONFIG['trusted_domains'] = [\n")
+	for index, domain := range domains {
+		builder.WriteString(fmt.Sprintf("  %d => '%s',\n", index, escapePHPString(domain)))
 	}
-	builder.WriteString("]);\n")
+	builder.WriteString("];\n")
 	return map[string]interface{}{
 		"nextcloud": map[string]interface{}{
 			"configs": map[string]interface{}{
@@ -296,6 +296,66 @@ func nextcloudTrustedDomainsPatch(ch *chart.Chart, values map[string]interface{}
 			},
 		},
 	}, nil
+}
+
+// nextcloudTrustedDomainList builds the full trusted_domains list: the probe
+// host, nextcloud.trustedDomains, httpRoute hostnames, localhost and the
+// cluster node IPs, deduplicated.
+func nextcloudTrustedDomainList(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) []string {
+	seen := map[string]bool{}
+	var domains []string
+	add := func(domain string) {
+		domain = strings.TrimSpace(domain)
+		if domain == "" || seen[domain] {
+			return
+		}
+		seen[domain] = true
+		domains = append(domains, domain)
+	}
+	add(nextcloudProbeHost(ch, values))
+	if nextcloud, ok := values["nextcloud"].(map[string]interface{}); ok {
+		for _, domain := range helmStringSlice(nextcloud["trustedDomains"]) {
+			add(domain)
+		}
+	}
+	if ch != nil && ch.Values != nil {
+		if defaultNextcloud, ok := ch.Values["nextcloud"].(map[string]interface{}); ok {
+			for _, domain := range helmStringSlice(defaultNextcloud["trustedDomains"]) {
+				add(domain)
+			}
+		}
+	}
+	for _, source := range []map[string]interface{}{values, ch.Values} {
+		if source == nil {
+			continue
+		}
+		if httpRoute, ok := source["httpRoute"].(map[string]interface{}); ok {
+			for _, domain := range helmStringSlice(httpRoute["hostnames"]) {
+				add(domain)
+			}
+		}
+	}
+	add("localhost")
+	for _, ip := range nodeIPs {
+		add(ip)
+	}
+	return domains
+}
+
+// helmStringSlice flattens a values field that may be []interface{} of strings
+// into a []string.
+func helmStringSlice(value interface{}) []string {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			result = append(result, text)
+		}
+	}
+	return result
 }
 
 // nextcloudProbeHost returns the effective nextcloud.host: the user-provided
@@ -316,6 +376,9 @@ func nextcloudProbeHost(ch *chart.Chart, values map[string]interface{}) string {
 	return "nextcloud.kube.home"
 }
 
+// escapePHPString escapes a value for a PHP single-quoted string: backslashes
+// first (they escape the quote otherwise), then single quotes.
 func escapePHPString(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
 	return strings.ReplaceAll(value, "'", "\\'")
 }

--- a/store/adapters.go
+++ b/store/adapters.go
@@ -19,6 +19,9 @@ type helmChartAdapter struct {
 	// generatedValuesPatchFn mints per-install values such as a random secret.
 	// The values preview skips it so the install dialog stays reproducible.
 	generatedValuesPatchFn func(explicitValues map[string]interface{}) (map[string]interface{}, error)
+	// clusterPatchFn mints patches that need cluster context (chart defaults,
+	// node IPs), e.g. Nextcloud trusted_domains. Skipped for the preview.
+	clusterPatchFn func(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) (map[string]interface{}, error)
 	// preservedValuePaths are carried over from the installed release on upgrade.
 	preservedValuePaths [][]string
 }
@@ -34,7 +37,10 @@ var helmChartAdapterRegistry = map[string]helmChartAdapter{
 		generatedValuesPatchFn: supersetSecretKeyPatch,
 		preservedValuePaths:    supersetPreservedValuePaths,
 	},
-	"nextcloud": {valuesPatches: nodePortServiceValuesPatch()},
+	"nextcloud": {
+		valuesPatches:  nodePortServiceValuesPatch(),
+		clusterPatchFn: nextcloudTrustedDomainsPatch,
+	},
 }
 
 // nodePortServiceValuesPatch returns a fresh patch each call so the registry
@@ -120,7 +126,7 @@ func supersetSecretKeyAlreadySet(values map[string]interface{}) bool {
 
 // applyHelmChartAdapter merges chart-specific compatibility values into the
 // install values; user-set top-level keys are left untouched.
-func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}, includeGenerated bool) error {
+func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]interface{}, includeGenerated bool, nodeIPs func() []string) error {
 	if ch == nil {
 		return nil
 	}
@@ -129,12 +135,25 @@ func applyHelmChartAdapter(ch *chart.Chart, values, explicitValues map[string]in
 		return nil
 	}
 	patches := adapter.valuesPatches
-	if includeGenerated && adapter.generatedValuesPatchFn != nil {
-		generated, err := adapter.generatedValuesPatchFn(explicitValues)
-		if err != nil {
-			return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+	if includeGenerated {
+		if adapter.generatedValuesPatchFn != nil {
+			generated, err := adapter.generatedValuesPatchFn(explicitValues)
+			if err != nil {
+				return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+			}
+			patches = mergedHelmAdapterPatches(patches, generated)
 		}
-		patches = mergedHelmAdapterPatches(patches, generated)
+		if adapter.clusterPatchFn != nil {
+			var ips []string
+			if nodeIPs != nil {
+				ips = nodeIPs()
+			}
+			clusterPatches, err := adapter.clusterPatchFn(ch, values, ips)
+			if err != nil {
+				return fmt.Errorf("apply Helm chart adapter for %s: %w", ch.Name(), err)
+			}
+			patches = mergedHelmAdapterPatches(patches, clusterPatches)
+		}
 	}
 	for topKey, patch := range patches {
 		if adapterPatchExplicitlyOverridden(explicitValues, topKey, patch) {
@@ -247,4 +266,56 @@ func adapterPatchExplicitlyOverridden(explicitValues map[string]interface{}, top
 		}
 	}
 	return false
+}
+
+// nextcloudTrustedDomainsPatch configures trusted_domains via the chart's
+// config.php fragment mechanism (nextcloud.configs). The fragment APPENDS to
+// any existing trusted_domains (chart defaults, metrics service names, user
+// ingress domains) instead of overwriting them.
+//
+// The probe host is resolved from the user values or the chart default
+// (nextcloud.host); the chart probes /status.php with that host, so omitting
+// it makes liveness fail and the pod restart-loop. Node IPs are the cluster
+// addresses the user reaches the app through; they are snapshotted at
+// install/upgrade time and refreshed on the next upgrade.
+//
+// The filename must match Nextcloud's *.config.php loading pattern, and this
+// fragment loads last (natsort), so $CONFIG already holds prior entries.
+func nextcloudTrustedDomainsPatch(ch *chart.Chart, values map[string]interface{}, nodeIPs []string) (map[string]interface{}, error) {
+	var builder strings.Builder
+	builder.WriteString("<?php\n$CONFIG['trusted_domains'] = array_merge($CONFIG['trusted_domains'] ?? [], [\n")
+	builder.WriteString(fmt.Sprintf("  0 => '%s',\n", escapePHPString(nextcloudProbeHost(ch, values))))
+	for index, ip := range nodeIPs {
+		builder.WriteString(fmt.Sprintf("  %d => '%s',\n", index+1, escapePHPString(ip)))
+	}
+	builder.WriteString("]);\n")
+	return map[string]interface{}{
+		"nextcloud": map[string]interface{}{
+			"configs": map[string]interface{}{
+				"trusted_domains.config.php": builder.String(),
+			},
+		},
+	}, nil
+}
+
+// nextcloudProbeHost returns the effective nextcloud.host: the user-provided
+// value if set, else the chart default, else the historical probe host.
+func nextcloudProbeHost(ch *chart.Chart, values map[string]interface{}) string {
+	if nextcloud, ok := values["nextcloud"].(map[string]interface{}); ok {
+		if host, ok := nextcloud["host"].(string); ok && strings.TrimSpace(host) != "" {
+			return host
+		}
+	}
+	if ch != nil && ch.Values != nil {
+		if nextcloud, ok := ch.Values["nextcloud"].(map[string]interface{}); ok {
+			if host, ok := nextcloud["host"].(string); ok && strings.TrimSpace(host) != "" {
+				return host
+			}
+		}
+	}
+	return "nextcloud.kube.home"
+}
+
+func escapePHPString(value string) string {
+	return strings.ReplaceAll(value, "'", "\\'")
 }

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -283,3 +283,65 @@ func TestPreserveHelmChartAdapterValuesIgnoresOtherCharts(t *testing.T) {
 		t.Errorf("charts without preserved paths must be left alone, got %#v", vals)
 	}
 }
+
+func TestNextcloudAdapterTrustedDomains(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithOptions(testChart("nextcloud"), "https://example.com/charts", map[string]interface{}{}, helmInstallValueOptions{
+		nodeIPs: func() []string { return []string{"192.168.10.101"} },
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	service, ok := values["service"].(map[string]interface{})
+	if !ok || service["type"] != "NodePort" {
+		t.Errorf("expected service.type NodePort, got %#v", values["service"])
+	}
+	nextcloud, ok := values["nextcloud"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nextcloud values, got %#v", values["nextcloud"])
+	}
+	configs, ok := nextcloud["configs"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nextcloud configs, got %#v", nextcloud)
+	}
+	content, _ := configs["trusted_domains.config.php"].(string)
+	if !strings.Contains(content, "nextcloud.kube.home") || !strings.Contains(content, "192.168.10.101") {
+		t.Errorf("trusted_domains fragment missing probe host or node IP: %q", content)
+	}
+	if !strings.Contains(content, "array_merge") {
+		t.Errorf("fragment must append to existing trusted_domains, got %q", content)
+	}
+}
+
+func TestNextcloudAdapterUsesUserHost(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithOptions(testChart("nextcloud"), "https://example.com/charts", map[string]interface{}{
+		"nextcloud": map[string]interface{}{"host": "cloud.example.com"},
+	}, helmInstallValueOptions{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	nextcloud, _ := values["nextcloud"].(map[string]interface{})
+	configs, _ := nextcloud["configs"].(map[string]interface{})
+	content, _ := configs["trusted_domains.config.php"].(string)
+	if !strings.Contains(content, "cloud.example.com") {
+		t.Errorf("fragment must use the user host, got %q", content)
+	}
+	if strings.Contains(content, "nextcloud.kube.home") {
+		t.Errorf("hardcoded probe host must not appear when user host is set: %q", content)
+	}
+}
+
+func TestNextcloudAdapterWithoutNodeIPs(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithOptions(testChart("nextcloud"), "https://example.com/charts", map[string]interface{}{}, helmInstallValueOptions{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	nextcloud, _ := values["nextcloud"].(map[string]interface{})
+	configs, _ := nextcloud["configs"].(map[string]interface{})
+	content, _ := configs["trusted_domains.config.php"].(string)
+	if !strings.Contains(content, "nextcloud.kube.home") {
+		t.Errorf("expected probe host in fragment, got %q", content)
+	}
+	if strings.Contains(content, "192.168") {
+		t.Errorf("expected no node IPs, got %q", content)
+	}
+}

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -304,11 +304,11 @@ func TestNextcloudAdapterTrustedDomains(t *testing.T) {
 		t.Fatalf("expected nextcloud configs, got %#v", nextcloud)
 	}
 	content, _ := configs["trusted_domains.config.php"].(string)
-	if !strings.Contains(content, "nextcloud.kube.home") || !strings.Contains(content, "192.168.10.101") {
-		t.Errorf("trusted_domains fragment missing probe host or node IP: %q", content)
+	if !strings.Contains(content, "nextcloud.kube.home") || !strings.Contains(content, "192.168.10.101") || !strings.Contains(content, "localhost") {
+		t.Errorf("trusted_domains fragment missing probe host, node IP or localhost: %q", content)
 	}
-	if !strings.Contains(content, "array_merge") {
-		t.Errorf("fragment must append to existing trusted_domains, got %q", content)
+	if strings.Contains(content, "array_merge") {
+		t.Errorf("fragment must replace the key with the full Go-computed list: %q", content)
 	}
 }
 
@@ -327,6 +327,64 @@ func TestNextcloudAdapterUsesUserHost(t *testing.T) {
 	}
 	if strings.Contains(content, "nextcloud.kube.home") {
 		t.Errorf("hardcoded probe host must not appear when user host is set: %q", content)
+	}
+}
+
+func TestNextcloudAdapterChartDefaultHost(t *testing.T) {
+	ch := testChart("nextcloud")
+	ch.Values["nextcloud"] = map[string]interface{}{"host": "chart-default.example.com"}
+	values, _, err := prepareHelmInstallValuesWithOptions(ch, "https://example.com/charts", map[string]interface{}{}, helmInstallValueOptions{})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	nextcloud, _ := values["nextcloud"].(map[string]interface{})
+	configs, _ := nextcloud["configs"].(map[string]interface{})
+	content, _ := configs["trusted_domains.config.php"].(string)
+	if !strings.Contains(content, "chart-default.example.com") {
+		t.Errorf("fragment must use the chart default host, got %q", content)
+	}
+	if strings.Contains(content, "nextcloud.kube.home") {
+		t.Errorf("fallback host must not appear when the chart default is set: %q", content)
+	}
+}
+
+func TestNextcloudAdapterIncludesTrustedDomainsAndHostnames(t *testing.T) {
+	values, _, err := prepareHelmInstallValuesWithOptions(testChart("nextcloud"), "https://example.com/charts", map[string]interface{}{
+		"nextcloud": map[string]interface{}{
+			"host":           "cloud.example.com",
+			"trustedDomains": []interface{}{"a.example.com", "b.example.com"},
+		},
+		"httpRoute": map[string]interface{}{
+			"hostnames": []interface{}{"route.example.com", "a.example.com"},
+		},
+	}, helmInstallValueOptions{
+		nodeIPs: func() []string { return []string{"192.168.10.101", "192.168.10.101"} },
+	})
+	if err != nil {
+		t.Fatalf("prepare values: %v", err)
+	}
+	nextcloud, _ := values["nextcloud"].(map[string]interface{})
+	configs, _ := nextcloud["configs"].(map[string]interface{})
+	content, _ := configs["trusted_domains.config.php"].(string)
+	for _, domain := range []string{"cloud.example.com", "a.example.com", "b.example.com", "route.example.com", "localhost", "192.168.10.101"} {
+		if !strings.Contains(content, domain) {
+			t.Errorf("fragment missing %q: %q", domain, content)
+		}
+	}
+	if strings.Count(content, "a.example.com") != 1 {
+		t.Errorf("duplicate domains must be deduplicated: %q", content)
+	}
+	if strings.Count(content, "192.168.10.101") != 1 {
+		t.Errorf("duplicate node IPs must be deduplicated: %q", content)
+	}
+}
+
+func TestEscapePHPString(t *testing.T) {
+	if got := escapePHPString("it's a\\test"); got != "it\\'s a\\\\test" {
+		t.Errorf("unexpected escaping: %q", got)
+	}
+	if got := escapePHPString("trailing\\"); got != "trailing\\\\" {
+		t.Errorf("trailing backslash must be escaped: %q", got)
 	}
 }
 

--- a/store/adapters_test.go
+++ b/store/adapters_test.go
@@ -291,24 +291,10 @@ func TestNextcloudAdapterTrustedDomains(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	service, ok := values["service"].(map[string]interface{})
-	if !ok || service["type"] != "NodePort" {
-		t.Errorf("expected service.type NodePort, got %#v", values["service"])
-	}
-	nextcloud, ok := values["nextcloud"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected nextcloud values, got %#v", values["nextcloud"])
-	}
-	configs, ok := nextcloud["configs"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected nextcloud configs, got %#v", nextcloud)
-	}
-	content, _ := configs["trusted_domains.config.php"].(string)
-	if !strings.Contains(content, "nextcloud.kube.home") || !strings.Contains(content, "192.168.10.101") || !strings.Contains(content, "localhost") {
-		t.Errorf("trusted_domains fragment missing probe host, node IP or localhost: %q", content)
-	}
-	if strings.Contains(content, "array_merge") {
-		t.Errorf("fragment must replace the key with the full Go-computed list: %q", content)
+	trusted := values["nextcloud"].(map[string]interface{})["trustedDomains"]
+	items, ok := trusted.([]string)
+	if !ok || !reflect.DeepEqual(items, []string{"localhost", "nextcloud.kube.home", "192.168.10.101"}) {
+		t.Errorf("unexpected trusted domains: %#v", trusted)
 	}
 }
 
@@ -319,14 +305,9 @@ func TestNextcloudAdapterUsesUserHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	nextcloud, _ := values["nextcloud"].(map[string]interface{})
-	configs, _ := nextcloud["configs"].(map[string]interface{})
-	content, _ := configs["trusted_domains.config.php"].(string)
-	if !strings.Contains(content, "cloud.example.com") {
-		t.Errorf("fragment must use the user host, got %q", content)
-	}
-	if strings.Contains(content, "nextcloud.kube.home") {
-		t.Errorf("hardcoded probe host must not appear when user host is set: %q", content)
+	trusted := values["nextcloud"].(map[string]interface{})["trustedDomains"]
+	if !reflect.DeepEqual(trusted, []string{"localhost", "cloud.example.com"}) {
+		t.Errorf("unexpected trusted domains: %#v", trusted)
 	}
 }
 
@@ -337,14 +318,9 @@ func TestNextcloudAdapterChartDefaultHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	nextcloud, _ := values["nextcloud"].(map[string]interface{})
-	configs, _ := nextcloud["configs"].(map[string]interface{})
-	content, _ := configs["trusted_domains.config.php"].(string)
-	if !strings.Contains(content, "chart-default.example.com") {
-		t.Errorf("fragment must use the chart default host, got %q", content)
-	}
-	if strings.Contains(content, "nextcloud.kube.home") {
-		t.Errorf("fallback host must not appear when the chart default is set: %q", content)
+	trusted := values["nextcloud"].(map[string]interface{})["trustedDomains"]
+	if !reflect.DeepEqual(trusted, []string{"localhost", "chart-default.example.com"}) {
+		t.Errorf("unexpected trusted domains: %#v", trusted)
 	}
 }
 
@@ -363,28 +339,10 @@ func TestNextcloudAdapterIncludesTrustedDomainsAndHostnames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	nextcloud, _ := values["nextcloud"].(map[string]interface{})
-	configs, _ := nextcloud["configs"].(map[string]interface{})
-	content, _ := configs["trusted_domains.config.php"].(string)
-	for _, domain := range []string{"cloud.example.com", "a.example.com", "b.example.com", "route.example.com", "localhost", "192.168.10.101"} {
-		if !strings.Contains(content, domain) {
-			t.Errorf("fragment missing %q: %q", domain, content)
-		}
-	}
-	if strings.Count(content, "a.example.com") != 1 {
-		t.Errorf("duplicate domains must be deduplicated: %q", content)
-	}
-	if strings.Count(content, "192.168.10.101") != 1 {
-		t.Errorf("duplicate node IPs must be deduplicated: %q", content)
-	}
-}
-
-func TestEscapePHPString(t *testing.T) {
-	if got := escapePHPString("it's a\\test"); got != "it\\'s a\\\\test" {
-		t.Errorf("unexpected escaping: %q", got)
-	}
-	if got := escapePHPString("trailing\\"); got != "trailing\\\\" {
-		t.Errorf("trailing backslash must be escaped: %q", got)
+	trusted := values["nextcloud"].(map[string]interface{})["trustedDomains"].([]string)
+	expected := []string{"localhost", "cloud.example.com", "a.example.com", "b.example.com", "route.example.com", "192.168.10.101"}
+	if !reflect.DeepEqual(trusted, expected) {
+		t.Errorf("expected %#v, got %#v", expected, trusted)
 	}
 }
 
@@ -393,13 +351,8 @@ func TestNextcloudAdapterWithoutNodeIPs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepare values: %v", err)
 	}
-	nextcloud, _ := values["nextcloud"].(map[string]interface{})
-	configs, _ := nextcloud["configs"].(map[string]interface{})
-	content, _ := configs["trusted_domains.config.php"].(string)
-	if !strings.Contains(content, "nextcloud.kube.home") {
-		t.Errorf("expected probe host in fragment, got %q", content)
-	}
-	if strings.Contains(content, "192.168") {
-		t.Errorf("expected no node IPs, got %q", content)
+	trusted := values["nextcloud"].(map[string]interface{})["trustedDomains"]
+	if !reflect.DeepEqual(trusted, []string{"localhost", "nextcloud.kube.home"}) {
+		t.Errorf("unexpected trusted domains: %#v", trusted)
 	}
 }

--- a/store/helm.go
+++ b/store/helm.go
@@ -142,6 +142,34 @@ func newHelmConfig(cfg *rest.Config, namespace string) (*action.Configuration, e
 	return newHelmConfigWithLog(cfg, namespace, func(string, ...interface{}) {})
 }
 
+// getClusterNodeIPs returns the internal IPs of all cluster nodes; used by
+// install adapters that need a reachable endpoint (e.g. Nextcloud
+// trusted_domains). Returns nil on any failure so adapters degrade gracefully.
+func getClusterNodeIPs(cfg *rest.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		logrus.Warnf("build node IP client: %v", err)
+		return nil
+	}
+	nodes, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		logrus.Warnf("list nodes for install adapter: %v", err)
+		return nil
+	}
+	var ips []string
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				ips = append(ips, address.Address)
+			}
+		}
+	}
+	return ips
+}
+
 func newHelmConfigWithLog(cfg *rest.Config, namespace string, logFn func(string, ...interface{})) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(newRESTClientGetter(cfg, namespace), namespace, "secret", logFn); err != nil {
@@ -1280,7 +1308,10 @@ func installHelmChart(cfg *rest.Config, releaseName, namespace, chartName, repoU
 	if err != nil {
 		return err
 	}
-	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides)
+	vals, adjustments, err := prepareHelmInstallValuesWithOptions(ch, repoURL, vals, helmInstallValueOptions{
+		inputIsOverrides: inputIsOverrides,
+		nodeIPs:          func() []string { return getClusterNodeIPs(cfg) },
+	})
 	if err != nil {
 		return err
 	}
@@ -1438,7 +1469,10 @@ func installHelmChartStream(ctx context.Context, lifecycle HelmInstallLifecycle,
 			finishWithError(err, "values parsing error")
 			return
 		}
-		vals, adjustments, err := prepareHelmInstallValuesWithMode(helmChart, repoURL, vals, inputIsOverrides)
+		vals, adjustments, err := prepareHelmInstallValuesWithOptions(helmChart, repoURL, vals, helmInstallValueOptions{
+			inputIsOverrides: inputIsOverrides,
+			nodeIPs:          func() []string { return getClusterNodeIPs(cfg) },
+		})
 		if err != nil {
 			finishWithError(err, "values preparation error")
 			return
@@ -1517,7 +1551,10 @@ func upgradeHelmRelease(cfg *rest.Config, releaseName, namespace, chartName, rep
 		return err
 	}
 	preserveHelmChartAdapterValues(actionConfig, ch, releaseName, vals)
-	vals, adjustments, err := prepareHelmInstallValuesWithMode(ch, repoURL, vals, inputIsOverrides)
+	vals, adjustments, err := prepareHelmInstallValuesWithOptions(ch, repoURL, vals, helmInstallValueOptions{
+		inputIsOverrides: inputIsOverrides,
+		nodeIPs:          func() []string { return getClusterNodeIPs(cfg) },
+	})
 	if err != nil {
 		return err
 	}

--- a/store/helm.go
+++ b/store/helm.go
@@ -160,11 +160,14 @@ func getClusterNodeIPs(cfg *rest.Config) []string {
 		return nil
 	}
 	var ips []string
+	seen := map[string]bool{}
 	for _, node := range nodes.Items {
 		for _, address := range node.Status.Addresses {
-			if address.Type == corev1.NodeInternalIP {
-				ips = append(ips, address.Address)
+			if address.Type != corev1.NodeInternalIP || seen[address.Address] {
+				continue
 			}
+			seen[address.Address] = true
+			ips = append(ips, address.Address)
 		}
 	}
 	return ips

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -96,7 +96,7 @@ func buildHelmChartInstallValues(ch *chart.Chart, repoURL string) (map[string]in
 	if ch == nil {
 		return map[string]interface{}{}, helmInstallValueAdjustments{}, nil
 	}
-	overrides, adjustments, err := prepareHelmInstallValuesWithOptions(ch, repoURL, map[string]interface{}{}, helmInstallValueOptions{skipGeneratedValues: true})
+	overrides, adjustments, err := prepareHelmInstallValuesWithOptions(ch, repoURL, map[string]interface{}{}, helmInstallValueOptions{skipDynamicValues: true})
 	if err != nil {
 		return nil, helmInstallValueAdjustments{}, err
 	}
@@ -109,10 +109,11 @@ func buildHelmChartInstallValues(ch *chart.Chart, repoURL string) (map[string]in
 
 type helmInstallValueOptions struct {
 	inputIsOverrides bool
-	// skipGeneratedValues leaves out per-install adapter values such as a random
-	// secret: the install dialog renders its baseline through this path, and a
-	// value that differs on every render is not the one the install uses.
-	skipGeneratedValues bool
+	// skipDynamicValues leaves out per-install adapter values: random
+	// secrets AND cluster-context patches (node IPs). The install dialog
+	// renders its baseline through this path so it stays reproducible and
+	// avoids the node list API call.
+	skipDynamicValues bool
 	// nodeIPs lazily resolves cluster node addresses for adapters that need a
 	// reachable endpoint (e.g. Nextcloud trusted_domains); may be nil.
 	nodeIPs func() []string
@@ -141,7 +142,7 @@ func prepareHelmInstallValuesWithOptions(ch *chart.Chart, repoURL string, input 
 		}
 		values, adjustments = bitnamiValues, bitnamiAdjustments
 	}
-	if err := applyHelmChartAdapter(ch, values, input, !options.skipGeneratedValues, options.nodeIPs); err != nil {
+	if err := applyHelmChartAdapter(ch, values, input, !options.skipDynamicValues, options.nodeIPs); err != nil {
 		return nil, adjustments, err
 	}
 	return values, adjustments, nil

--- a/store/helm_install_values.go
+++ b/store/helm_install_values.go
@@ -113,6 +113,9 @@ type helmInstallValueOptions struct {
 	// secret: the install dialog renders its baseline through this path, and a
 	// value that differs on every render is not the one the install uses.
 	skipGeneratedValues bool
+	// nodeIPs lazily resolves cluster node addresses for adapters that need a
+	// reachable endpoint (e.g. Nextcloud trusted_domains); may be nil.
+	nodeIPs func() []string
 }
 
 // prepareHelmInstallValues computes compatibility changes from Helm's fully
@@ -138,7 +141,7 @@ func prepareHelmInstallValuesWithOptions(ch *chart.Chart, repoURL string, input 
 		}
 		values, adjustments = bitnamiValues, bitnamiAdjustments
 	}
-	if err := applyHelmChartAdapter(ch, values, input, !options.skipGeneratedValues); err != nil {
+	if err := applyHelmChartAdapter(ch, values, input, !options.skipGeneratedValues, options.nodeIPs); err != nil {
 		return nil, adjustments, err
 	}
 	return values, adjustments, nil


### PR DESCRIPTION
## What

Replaces the Nextcloud-specific PHP config generator with a generic endpoint binding mechanism that writes to the chart's native `nextcloud.trustedDomains` values array.

The generic binding computes and deduplicates the endpoint list from:
- `localhost`
- the effective `nextcloud.host` or chart fallback
- user-provided `nextcloud.trustedDomains`
- `httpRoute.hostnames`
- cluster node IPs

Nextcloud now declares only the values paths and endpoint sources; it no longer contains PHP generation logic.

## Why

Issue #121: make Nextcloud usable immediately after installation without manual `trusted_domains` configuration.

The previous implementation generated PHP fragments in CasOS code. That coupled CasOS to Nextcloud's internal PHP config loading behavior and required application-specific escaping and tests. The generic binding makes the mechanism reusable: future charts can add endpoint metadata instead of another custom code path.

## Changes

- Added generic `helmEndpointBinding` metadata.
- Added generic endpoint list calculation and nested values-path read/write helpers.
- Changed Nextcloud to use the chart-native `nextcloud.trustedDomains` path.
- Removed `nextcloudTrustedDomainsPatch`, `nextcloudTrustedDomainList`, `nextcloudProbeHost`, and `escapePHPString`.
- Removed the unused `clusterPatchFn` adapter field.
- Updated tests to validate final Helm values rather than generated PHP strings.

## Notes

- The chart's `NEXTCLOUD_TRUSTED_DOMAINS` environment variable is processed during initial installation. Day-2 changes to node addresses may require manual configuration or reinstall; this is acceptable for the current install-and-use goal and should be documented separately.
- User-provided trusted domains and chart defaults are merged with CasOS endpoint addresses rather than discarded.
- Existing lazy node-IP resolution is preserved; charts without endpoint bindings do not trigger the node list lookup.

## Verification

- `GOPROXY=https://goproxy.cn,direct go test ./store` passes.
- `git diff --check` passes.
- Full `go test ./...` is currently blocked by permission denied on an existing Kubernetes PVC directory under `data/local-path-provisioner/`, unrelated to this change.