### PR TITLE
feat(storage): use SQLite by default with separate Kine state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
           --health-timeout=5s
           --health-retries=10
     env:
+      driverName: mysql
       dataSourceName: root:casos-${{ github.run_id }}-${{ github.run_attempt }}@tcp(127.0.0.1:3306)/
       dbName: casos
       socks5Proxy: ""

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ casos/
 
 - **Backend**: [Go](https://golang.org/dl/) 1.26+
 - **Frontend**: [Node.js](https://nodejs.org/) 20+ and [Yarn](https://classic.yarnpkg.com/) 1.x
-- MySQL database
 - A [Casdoor](https://casdoor.org) instance (for authentication)
 
 Supported platforms: **Linux**, **macOS**, **Windows**
@@ -84,9 +83,10 @@ httpport      = 9000
 runmode       = dev
 
 ; Database
-driverName    = mysql
-dataSourceName= user:pass@tcp(host:3306)/
+driverName    = sqlite
+dataSourceName=
 dbName        = casos
+kineEndpoint  =
 
 ; Casdoor
 casdoorEndpoint     = https://your-casdoor-instance
@@ -103,8 +103,19 @@ socks5Proxy =
 ; Kubernetes control plane
 apiserverPort = 6443
 apiserverBind = 127.0.0.1
-dataDir       = /var/lib/casos
+dataDir       = ./data
 ```
+
+SQLite is the default and stores CasOS business data in `data/casos.db` and
+Kubernetes state in `data/kine/state.db`. The `data` directory is ignored by
+Git and is writable when running the development command from the repository
+root. System installations should set `dataDir` to a persistent directory such
+as `/var/lib/casos` and ensure the service user can write to it.
+
+MySQL remains available by setting `driverName=mysql`, configuring
+`dataSourceName` and `dbName`, and optionally setting a complete
+`kineEndpoint`. Switching an existing installation from MySQL to SQLite starts
+with empty SQLite databases; existing MySQL data is not imported automatically.
 
 The control-plane proxy accepts `host:port`, `socks5://`, and `socks5h://`
 addresses. When `socks5Proxy` is set, CasOS fails requests that cannot use the

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -5,9 +5,10 @@ SessionOn     = true
 copyrequestbody = true
 
 ; -- Database ---------------------------------------------------------------
-driverName    = mysql
-dataSourceName= root:123456@tcp(localhost:3306)/
+driverName    = sqlite
+dataSourceName=
 dbName        = casos
+kineEndpoint  =
 
 ; -- Casdoor -------------------------------------------------------------------
 casdoorEndpoint     = https://door.casdoor.com
@@ -37,6 +38,6 @@ helmInstallTimeout = 20m
 ; -- Control plane ----------------------------------------------------------
 apiserverPort = 6443
 apiserverBind = 127.0.0.1
-dataDir       = /var/lib/casos
+dataDir       = ./data
 ingressControllerEnabled = true
 serviceLBEnabled = true

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -17,6 +17,7 @@ package conf
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -24,6 +25,8 @@ import (
 	"github.com/beego/beego"
 	"github.com/beego/beego/logs"
 )
+
+const DefaultDataDir = "./data"
 
 func init() {
 	// this array contains the beego configuration items that may be modified via env
@@ -141,6 +144,38 @@ func GetConfigDataSourceName() string {
 	return dataSourceName
 }
 
+func GetDatabaseDriverName() string {
+	driverName := strings.ToLower(GetConfigStringDefault("driverName", "sqlite"))
+	if driverName == "sqlite3" {
+		return "sqlite"
+	}
+	return driverName
+}
+
+func GetDatabaseDataSourceName() string {
+	return resolveDatabaseDataSourceName(
+		GetDatabaseDriverName(),
+		GetConfigDataSourceName(),
+		GetDataDir(),
+	)
+}
+
+func GetDataDir() string {
+	dataDir := GetConfigStringDefault("dataDir", DefaultDataDir)
+	absolutePath, err := filepath.Abs(dataDir)
+	if err != nil {
+		return dataDir
+	}
+	return absolutePath
+}
+
+func resolveDatabaseDataSourceName(driverName, dataSourceName, dataDir string) string {
+	if driverName == "sqlite" && strings.TrimSpace(dataSourceName) == "" {
+		return filepath.Join(dataDir, "casos.db")
+	}
+	return dataSourceName
+}
+
 func GetLanguage(language string) string {
 	if language == "" || language == "*" {
 		return "en"
@@ -166,11 +201,9 @@ func GetConfigBatchSize() int {
 }
 
 func GetConfigRealDataSourceName(driverName string) string {
-	var dataSourceName string
-	if driverName != "mysql" {
-		dataSourceName = GetConfigDataSourceName()
-	} else {
-		dataSourceName = GetConfigDataSourceName() + GetConfigString("dbName")
+	dataSourceName := GetDatabaseDataSourceName()
+	if driverName == "mysql" {
+		dataSourceName += GetConfigStringDefault("dbName", "casos")
 	}
 	return dataSourceName
 }

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -1,0 +1,69 @@
+package conf
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDatabaseDataSourceName(t *testing.T) {
+	dataDir := t.TempDir()
+
+	tests := []struct {
+		name           string
+		driverName     string
+		dataSourceName string
+		want           string
+	}{
+		{
+			name:       "default SQLite path",
+			driverName: "sqlite",
+			want:       filepath.Join(dataDir, "casos.db"),
+		},
+		{
+			name:           "configured SQLite path",
+			driverName:     "sqlite",
+			dataSourceName: filepath.Join(dataDir, "custom.db"),
+			want:           filepath.Join(dataDir, "custom.db"),
+		},
+		{
+			name:           "MySQL DSN",
+			driverName:     "mysql",
+			dataSourceName: "root:secret@tcp(localhost:3306)/",
+			want:           "root:secret@tcp(localhost:3306)/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDatabaseDataSourceName(tt.driverName, tt.dataSourceName, dataDir)
+			if got != tt.want {
+				t.Fatalf("resolveDatabaseDataSourceName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultSQLiteDataSourceName(t *testing.T) {
+	want := filepath.Join(DefaultDataDir, "casos.db")
+	if got := resolveDatabaseDataSourceName("sqlite", "", DefaultDataDir); got != want {
+		t.Fatalf("resolveDatabaseDataSourceName() = %q, want %q", got, want)
+	}
+}
+
+func TestGetDataDirReturnsAbsolutePath(t *testing.T) {
+	t.Setenv("dataDir", "./data")
+	got := GetDataDir()
+	if !filepath.IsAbs(got) {
+		t.Fatalf("GetDataDir() = %q, want an absolute path", got)
+	}
+	if filepath.Base(got) != "data" {
+		t.Fatalf("GetDataDir() = %q, want data directory", got)
+	}
+}
+
+func TestGetDatabaseDriverNameNormalizesSQLiteAlias(t *testing.T) {
+	t.Setenv("driverName", "sqlite3")
+	if got := GetDatabaseDriverName(); got != "sqlite" {
+		t.Fatalf("GetDatabaseDriverName() = %q, want sqlite", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -67,11 +67,13 @@ require (
 	github.com/casdoor/casdoor-go-sdk v0.52.0
 	github.com/go-sql-driver/mysql v1.10.0
 
-	// kine: MySQL as etcd backend
+	// kine: SQL datastore exposed as an etcd-compatible backend
 	github.com/k3s-io/kine v0.16.1
 	github.com/sirupsen/logrus v1.9.4
+	go.etcd.io/etcd/client/v3 v3.6.12
 	k8s.io/apimachinery v1.36.1-k3s1
 	k8s.io/client-go v1.36.1-k3s1
+	modernc.org/sqlite v1.51.0
 
 	// Kubernetes control plane (k3s fork tags)
 	k8s.io/kubernetes v1.36.1-k3s1
@@ -273,7 +275,6 @@ require (
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.12 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.12 // indirect
-	go.etcd.io/etcd/client/v3 v3.6.12 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.6.12 // indirect
 	go.etcd.io/etcd/server/v3 v3.6.11 // indirect
 	go.etcd.io/raft/v3 v3.6.0 // indirect
@@ -338,7 +339,6 @@ require (
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.51.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/object/machine_node_deploy.go
+++ b/object/machine_node_deploy.go
@@ -480,10 +480,7 @@ func machineNodeCredentialSecret() (string, error) {
 		return secret, nil
 	}
 
-	dataDir := strings.TrimSpace(conf.GetConfigString("dataDir"))
-	if dataDir == "" {
-		dataDir = "/var/lib/casos"
-	}
+	dataDir := conf.GetDataDir()
 	secretPath := filepath.Join(dataDir, machineNodeCredentialKeyFile)
 	if data, err := os.ReadFile(secretPath); err == nil {
 		secret := strings.TrimSpace(string(data))

--- a/object/ormer.go
+++ b/object/ormer.go
@@ -18,11 +18,15 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/casosorg/casos/conf"
 	_ "github.com/go-sql-driver/mysql" // db = mysql
+	_ "modernc.org/sqlite"             // db = sqlite
 	"xorm.io/xorm"
 	"xorm.io/xorm/names"
 )
@@ -52,14 +56,17 @@ func InitConfig() {
 }
 
 func InitAdapter() {
+	driverName := conf.GetDatabaseDriverName()
+	dataSourceName := conf.GetDatabaseDataSourceName()
+	dbName := conf.GetConfigStringDefault("dbName", "casos")
 	if createDatabase {
-		err := createDatabaseForPostgres(conf.GetConfigString("driverName"), conf.GetConfigDataSourceName(), conf.GetConfigString("dbName"))
+		err := createDatabaseForPostgres(driverName, dataSourceName, dbName)
 		if err != nil {
 			panic(err)
 		}
 	}
 
-	ormer = NewAdapter(conf.GetConfigString("driverName"), conf.GetConfigDataSourceName(), conf.GetConfigString("dbName"))
+	ormer = NewAdapter(driverName, dataSourceName, dbName)
 
 	tableNamePrefix := conf.GetConfigString("tableNamePrefix")
 	tbMapper := names.NewPrefixMapper(names.SnakeMapper{}, tableNamePrefix)
@@ -77,7 +84,7 @@ func CreateTables() {
 	ormer.createTable()
 }
 
-// Ormer represents the MySQL adapter for policy storage.
+// Ormer represents the SQL adapter for policy storage.
 type Ormer struct {
 	driverName     string
 	dataSourceName string
@@ -95,6 +102,9 @@ func finalizer(a *Ormer) {
 
 // NewAdapter is the constructor for Ormer.
 func NewAdapter(driverName string, dataSourceName string, dbName string) *Ormer {
+	if driverName == "sqlite3" {
+		driverName = "sqlite"
+	}
 	a := &Ormer{}
 	a.driverName = driverName
 	a.dataSourceName = dataSourceName
@@ -131,7 +141,7 @@ func createDatabaseForPostgres(driverName string, dataSourceName string, dbName 
 }
 
 func (a *Ormer) CreateDatabase() error {
-	if a.driverName == "postgres" {
+	if a.driverName == "postgres" || isSQLiteDriver(a.driverName) {
 		return nil
 	}
 
@@ -150,13 +160,58 @@ func (a *Ormer) open() {
 	if a.driverName != "mysql" {
 		dataSourceName = a.dataSourceName
 	}
+	if isSQLiteDriver(a.driverName) {
+		if err := ensureSQLiteDirectory(dataSourceName); err != nil {
+			panic(err)
+		}
+		dataSourceName = sqliteDataSourceName(dataSourceName)
+	}
 
 	engine, err := xorm.NewEngine(a.driverName, dataSourceName)
 	if err != nil {
 		panic(err)
 	}
+	if isSQLiteDriver(a.driverName) {
+		engine.SetMaxOpenConns(1)
+		engine.SetMaxIdleConns(1)
+	}
 
 	a.Engine = engine
+}
+
+func isSQLiteDriver(driverName string) bool {
+	return driverName == "sqlite"
+}
+
+func sqliteDataSourceName(dataSourceName string) string {
+	separator := "?"
+	if strings.Contains(dataSourceName, "?") {
+		separator = "&"
+	}
+	return dataSourceName + separator + "_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_txlock=immediate"
+}
+
+func ensureSQLiteDirectory(dataSourceName string) error {
+	databasePath := strings.SplitN(dataSourceName, "?", 2)[0]
+	if strings.HasPrefix(databasePath, "file:") {
+		uri, err := url.Parse(databasePath)
+		if err != nil {
+			return fmt.Errorf("parse SQLite data source: %w", err)
+		}
+		databasePath = uri.Path
+		if uri.Host != "" {
+			databasePath = "//" + uri.Host + databasePath
+		} else if runtime.GOOS == "windows" && len(databasePath) >= 3 && databasePath[0] == '/' && databasePath[2] == ':' {
+			databasePath = databasePath[1:]
+		}
+	}
+	if databasePath == "" || databasePath == ":memory:" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0o700); err != nil {
+		return fmt.Errorf("create SQLite database directory: %w", err)
+	}
+	return nil
 }
 
 func PingDatabase() error {

--- a/object/ormer_sqlite_test.go
+++ b/object/ormer_sqlite_test.go
@@ -1,0 +1,59 @@
+package object
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSQLiteAdapterConfiguration(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "nested", "casos.db")
+	adapter := NewAdapter("sqlite", databasePath, "")
+	t.Cleanup(func() {
+		adapter.close()
+	})
+
+	if err := adapter.Engine.Ping(); err != nil {
+		t.Fatalf("ping SQLite database: %v", err)
+	}
+	if got := adapter.Engine.DB().Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("MaxOpenConnections = %d, want 1", got)
+	}
+
+	var journalMode string
+	if _, err := adapter.Engine.SQL("PRAGMA journal_mode").Get(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var busyTimeout int
+	if _, err := adapter.Engine.SQL("PRAGMA busy_timeout").Get(&busyTimeout); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busyTimeout != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000", busyTimeout)
+	}
+
+	adapter.createTable()
+	exists, err := adapter.Engine.IsTableExist(new(Site))
+	if err != nil {
+		t.Fatalf("check Site table: %v", err)
+	}
+	if !exists {
+		t.Fatal("Site table was not created")
+	}
+}
+
+func TestSQLite3DriverAlias(t *testing.T) {
+	adapter := NewAdapter("sqlite3", filepath.Join(t.TempDir(), "casos.db"), "")
+	t.Cleanup(func() {
+		adapter.close()
+	})
+	if adapter.driverName != "sqlite" {
+		t.Fatalf("driverName = %q, want sqlite", adapter.driverName)
+	}
+	if err := adapter.Engine.Ping(); err != nil {
+		t.Fatalf("ping SQLite database: %v", err)
+	}
+}

--- a/server/apiserver.go
+++ b/server/apiserver.go
@@ -3,18 +3,19 @@ package server
 import (
 	"context"
 	"crypto/tls"
-	"database/sql"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/casosorg/casos/util"
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/k3s-io/kine/pkg/endpoint"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	globalflag "k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/logs"
@@ -23,8 +24,9 @@ import (
 )
 
 const (
-	serviceClusterIPRange = "10.43.0.0/16"
-	kubernetesServiceIP   = "10.43.0.1"
+	serviceClusterIPRange      = "10.43.0.0/16"
+	kubernetesServiceIP        = "10.43.0.1"
+	kubernetesEndpointsEtcdKey = "/registry/services/endpoints/default/kubernetes"
 )
 
 // Start launches kine and the apiserver in-process.
@@ -44,13 +46,18 @@ func Start(ctx context.Context, cfg Config) (<-chan struct{}, error) {
 	if err := util.StopOldInstance(2379); err != nil {
 		logrus.Warnf("failed to stop old instance on port 2379: %v", err)
 	}
-	etcdCfg, err := endpoint.Listen(ctx, kineEndpointConfig(cfg.DSN))
+	if err := ensureKineDataDirectory(cfg.DatastoreEndpoint); err != nil {
+		return nil, err
+	}
+	etcdCfg, err := endpoint.Listen(ctx, kineEndpointConfig(cfg.DatastoreEndpoint))
 	if err != nil {
 		return nil, fmt.Errorf("kine listen: %w", err)
 	}
 	logrus.Infof("kine started, etcd endpoint: %v", etcdCfg.Endpoints)
 
-	if err := deleteStaleKubernetesEndpoints(cfg.DSN); err != nil {
+	cleanupCtx, cancelCleanup := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelCleanup()
+	if err := deleteStaleKubernetesEndpoints(cleanupCtx, etcdCfg.Endpoints[0]); err != nil {
 		logrus.Warnf("failed to delete stale kubernetes endpoints: %v", err)
 	}
 
@@ -95,14 +102,31 @@ func Start(ctx context.Context, cfg Config) (<-chan struct{}, error) {
 	return readyCh, nil
 }
 
-func kineEndpointConfig(dsn string) endpoint.Config {
+func kineEndpointConfig(datastoreEndpoint string) endpoint.Config {
 	return endpoint.Config{
-		Endpoint:            "mysql://" + dsn,
+		Endpoint:            datastoreEndpoint,
 		Listener:            "tcp://127.0.0.1:2379",
 		EmulatedETCDVersion: "3.6.11",
 		CompactBatchSize:    100,
 		NotifyInterval:      time.Second,
 	}
+}
+
+func ensureKineDataDirectory(datastoreEndpoint string) error {
+	if !strings.HasPrefix(datastoreEndpoint, "sqlite://") {
+		return nil
+	}
+	databasePath := strings.SplitN(strings.TrimPrefix(datastoreEndpoint, "sqlite://"), "?", 2)[0]
+	if databasePath == "" {
+		return fmt.Errorf("SQLite kine endpoint has no database path")
+	}
+	if runtime.GOOS == "windows" && len(databasePath) >= 3 && databasePath[0] == '/' && databasePath[2] == ':' {
+		databasePath = databasePath[1:]
+	}
+	if err := os.MkdirAll(filepath.Dir(databasePath), 0o700); err != nil {
+		return fmt.Errorf("mkdir kine data directory: %w", err)
+	}
+	return nil
 }
 
 // waitForAPIServer polls /readyz every 2 s until it gets HTTP 200 or ctx is done.
@@ -174,14 +198,19 @@ func buildApiserverArgs(cfg Config, certDir, etcdEndpoint, authzKubeconfig strin
 }
 
 // deleteStaleKubernetesEndpoints removes the default/kubernetes Endpoints object
-// from kine's MySQL table so the bootstrap controller starts fresh on each run.
-func deleteStaleKubernetesEndpoints(dsn string) error {
-	db, err := sql.Open("mysql", dsn)
+// through kine so the bootstrap controller starts fresh on each run.
+func deleteStaleKubernetesEndpoints(ctx context.Context, etcdEndpoint string) error {
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{etcdEndpoint},
+		DialTimeout: 5 * time.Second,
+	})
 	if err != nil {
 		return err
 	}
-	defer db.Close()
-	const q = `UPDATE kine SET deleted=1 WHERE name='/registry/endpoints/default/kubernetes' AND deleted=0`
-	_, err = db.Exec(q)
+	defer client.Close()
+	_, err = client.Txn(ctx).Then(
+		clientv3.OpGet(kubernetesEndpointsEtcdKey),
+		clientv3.OpDelete(kubernetesEndpointsEtcdKey),
+	).Commit()
 	return err
 }

--- a/server/config.go
+++ b/server/config.go
@@ -3,9 +3,11 @@ package server
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"strings"
 
 	"github.com/casosorg/casos/conf"
+	kinesqlite "github.com/k3s-io/kine/pkg/drivers/sqlite"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,7 +18,7 @@ type Config struct {
 	AdvertiseAddress          string // non-loopback IP registered as kubernetes service endpoint
 	ApiserverPort             int
 	WebhookPort               int                // HTTPS port for the Casbin admission webhook server
-	DSN                       string             // MySQL DSN forwarded to kine
+	DatastoreEndpoint         string             // Kine datastore endpoint
 	SandboxImage              string             // containerd sandbox (pause) image, empty = upstream default
 	CoreDNSImage              string             // CoreDNS image used by the built-in DNS bootstrap
 	LocalPathProvisionerImage string             // local-path-provisioner controller image
@@ -33,18 +35,22 @@ type Config struct {
 
 // ConfigFromAppConf reads server config from the beego app.conf.
 func ConfigFromAppConf() (Config, error) {
-	dataDir := conf.GetConfigStringDefault("dataDir", "/var/lib/casos")
+	dataDir := conf.GetDataDir()
 	bind := conf.GetConfigStringDefault("apiserverBind", outboundIP())
 	port := conf.GetConfigIntDefault("apiserverPort", 6443)
-	dsn := conf.GetConfigString("dataSourceName")
-	if dsn == "" {
-		return Config{}, fmt.Errorf("dataSourceName not set in app.conf")
+	driverName := conf.GetDatabaseDriverName()
+	dataSourceName := conf.GetDatabaseDataSourceName()
+	dbName := conf.GetConfigStringDefault("dbName", "casos")
+	datastoreEndpoint, err := resolveDatastoreEndpoint(
+		driverName,
+		dataSourceName,
+		dbName,
+		dataDir,
+		conf.GetConfigString("kineEndpoint"),
+	)
+	if err != nil {
+		return Config{}, err
 	}
-	dbName := conf.GetConfigString("dbName")
-	if dbName == "" {
-		dbName = "casos"
-	}
-	dsn = injectDBName(dsn, dbName)
 
 	advertise := outboundIP()
 	if advertise == "127.0.0.1" || advertise == "::1" {
@@ -75,7 +81,7 @@ func ConfigFromAppConf() (Config, error) {
 		AdvertiseAddress:          advertise,
 		ApiserverPort:             port,
 		WebhookPort:               webhookPort,
-		DSN:                       dsn,
+		DatastoreEndpoint:         datastoreEndpoint,
 		SandboxImage:              sandboxImage,
 		CoreDNSImage:              coreDNSImage,
 		LocalPathProvisionerImage: localPathProvisionerImage,
@@ -91,6 +97,25 @@ func ConfigFromAppConf() (Config, error) {
 	}
 	normalizeApplicationAccessConfig(&config)
 	return config, nil
+}
+
+func resolveDatastoreEndpoint(driverName, dataSourceName, dbName, dataDir, configuredEndpoint string) (string, error) {
+	if configuredEndpoint = strings.TrimSpace(configuredEndpoint); configuredEndpoint != "" {
+		if !strings.Contains(configuredEndpoint, "://") {
+			return "", fmt.Errorf("kineEndpoint must include a datastore scheme")
+		}
+		return configuredEndpoint, nil
+	}
+
+	switch driverName {
+	case "sqlite":
+		path := filepath.ToSlash(filepath.Join(dataDir, "kine", "state.db"))
+		return "sqlite://" + path + "?" + kinesqlite.DefaultParams, nil
+	case "mysql":
+		return "mysql://" + injectDBName(dataSourceName, dbName), nil
+	default:
+		return "", fmt.Errorf("kineEndpoint is required for database driver %q", driverName)
+	}
 }
 
 func normalizeApplicationAccessConfig(config *Config) {

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	kinesqlite "github.com/k3s-io/kine/pkg/drivers/sqlite"
+	"github.com/k3s-io/kine/pkg/endpoint"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func TestResolveDatastoreEndpoint(t *testing.T) {
+	dataDir := t.TempDir()
+
+	t.Run("SQLite uses dedicated state file", func(t *testing.T) {
+		got, err := resolveDatastoreEndpoint("sqlite", filepath.Join(dataDir, "casos.db"), "casos", dataDir, "")
+		if err != nil {
+			t.Fatalf("resolveDatastoreEndpoint() error = %v", err)
+		}
+		wantPrefix := "sqlite://" + filepath.ToSlash(filepath.Join(dataDir, "kine", "state.db")) + "?"
+		if !strings.HasPrefix(got, wantPrefix) {
+			t.Fatalf("endpoint = %q, want prefix %q", got, wantPrefix)
+		}
+		if !strings.HasSuffix(got, kinesqlite.DefaultParams) {
+			t.Fatalf("endpoint = %q, want Kine SQLite defaults", got)
+		}
+	})
+
+	t.Run("MySQL remains supported", func(t *testing.T) {
+		got, err := resolveDatastoreEndpoint("mysql", "root:secret@tcp(localhost:3306)/", "casos", dataDir, "")
+		if err != nil {
+			t.Fatalf("resolveDatastoreEndpoint() error = %v", err)
+		}
+		want := "mysql://root:secret@tcp(localhost:3306)/casos"
+		if got != want {
+			t.Fatalf("endpoint = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("explicit endpoint takes precedence", func(t *testing.T) {
+		const endpoint = "postgres://postgres:secret@localhost/casos"
+		got, err := resolveDatastoreEndpoint("postgres", "", "casos", dataDir, endpoint)
+		if err != nil {
+			t.Fatalf("resolveDatastoreEndpoint() error = %v", err)
+		}
+		if got != endpoint {
+			t.Fatalf("endpoint = %q, want %q", got, endpoint)
+		}
+	})
+}
+
+func TestKineSQLiteEndpoint(t *testing.T) {
+	dataDir := t.TempDir()
+	datastoreEndpoint, err := resolveDatastoreEndpoint("sqlite", "", "casos", dataDir, "")
+	if err != nil {
+		t.Fatalf("resolveDatastoreEndpoint() error = %v", err)
+	}
+	if err := ensureKineDataDirectory(datastoreEndpoint); err != nil {
+		t.Fatalf("ensureKineDataDirectory() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	kineConfig := kineEndpointConfig(datastoreEndpoint)
+	kineConfig.Listener = "tcp://127.0.0.1:0"
+	kineConfig.WaitGroup = &wg
+	etcdConfig, err := endpoint.Listen(ctx, kineConfig)
+	if err != nil {
+		cancel()
+		t.Fatalf("start Kine: %v", err)
+	}
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   etcdConfig.Endpoints,
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("create etcd client: %v", err)
+	}
+
+	requestCtx, requestCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if _, err = client.Put(requestCtx, "/casos/test", "value"); err != nil {
+		requestCancel()
+		client.Close()
+		cancel()
+		t.Fatalf("write through Kine: %v", err)
+	}
+	response, err := client.Get(requestCtx, "/casos/test")
+	if err != nil {
+		requestCancel()
+		client.Close()
+		cancel()
+		t.Fatalf("read through Kine: %v", err)
+	}
+	if len(response.Kvs) != 1 || string(response.Kvs[0].Value) != "value" {
+		cancel()
+		t.Fatalf("unexpected Kine response: %+v", response.Kvs)
+	}
+	if _, err = client.Put(requestCtx, kubernetesEndpointsEtcdKey, "stale"); err != nil {
+		requestCancel()
+		client.Close()
+		cancel()
+		t.Fatalf("seed stale Kubernetes Endpoints: %v", err)
+	}
+	if err = deleteStaleKubernetesEndpoints(requestCtx, etcdConfig.Endpoints[0]); err != nil {
+		requestCancel()
+		client.Close()
+		cancel()
+		t.Fatalf("delete stale Kubernetes Endpoints: %v", err)
+	}
+	response, err = client.Get(requestCtx, kubernetesEndpointsEtcdKey)
+	requestCancel()
+	client.Close()
+	if err != nil {
+		cancel()
+		t.Fatalf("read deleted Kubernetes Endpoints: %v", err)
+	}
+	if len(response.Kvs) != 0 {
+		cancel()
+		t.Fatalf("stale Kubernetes Endpoints still exists: %+v", response.Kvs)
+	}
+
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Kine shutdown")
+	}
+
+	statePath := filepath.Join(dataDir, "kine", "state.db")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("stat Kine state database: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Use SQLite for CasOS business data by default and keep Kubernetes state in a separate Kine SQLite database.
- Preserve explicit MySQL support and make CI select it explicitly.
- Normalize the writable development data directory and document the non-migrating MySQL switch.
- Add configuration, SQLite schema, and Kine operation tests.

## Validation
- `GOPROXY=https://goproxy.cn,direct go test -tags skipCi ./...`
- `CGO_ENABLED=0 GOPROXY=https://goproxy.cn,direct go test -tags skipCi ./conf ./object ./server`
- `GOPROXY=https://goproxy.cn,direct go vet -tags skipCi ./...`
- Real default startup: API `/readyz` and Web returned HTTP 200; both SQLite files were created.

The `skipCi` tag avoids the existing i18n generator tests that rewrite tracked locale files.